### PR TITLE
WIP: 76 add related identifier entry in metadata

### DIFF
--- a/daiquiri/metadata/models.py
+++ b/daiquiri/metadata/models.py
@@ -112,8 +112,8 @@ class Table(models.Model):
     TYPE_TABLE = 'table'
     TYPE_VIEW = 'view'
     TYPE_CHOICES = (
-        (TYPE_TABLE, _('Table')),
-        (TYPE_VIEW, _('View'))
+        (TYPE_TABLE, _('table')),
+        (TYPE_VIEW, _('view'))
     )
 
     objects = AccessLevelManager()

--- a/daiquiri/metadata/models.py
+++ b/daiquiri/metadata/models.py
@@ -51,6 +51,10 @@ class Schema(models.Model):
         max_length=256, null=True, blank=True,
         verbose_name=_('Digital object identifier')
     )
+    related_identifiers = JSONField(
+        null=True, blank=True,
+        verbose_name=_('Related Identifiers'),
+    )
     utype = models.CharField(
         max_length=256, null=True, blank=True,
         verbose_name=_('IVOA Utype'),
@@ -160,6 +164,10 @@ class Table(models.Model):
     doi = models.CharField(
         max_length=256, null=True, blank=True,
         verbose_name=_('Digital object identifier')
+    )
+    related_identifiers = JSONField(
+        null=True, blank=True,
+        verbose_name=_('Related Identifiers'),
     )
     type = models.CharField(
         max_length=8, choices=TYPE_CHOICES,

--- a/daiquiri/metadata/serializers/__init__.py
+++ b/daiquiri/metadata/serializers/__init__.py
@@ -59,6 +59,7 @@ class TableSerializer(serializers.ModelSerializer):
 
     label = serializers.CharField(source='__str__', read_only=True)
 
+    related_identifiers = JSONListField(allow_null=True, default=[])
     creators = JSONListField(allow_null=True, default=[])
     contributors = JSONListField(allow_null=True, default=[])
 
@@ -71,6 +72,7 @@ class SchemaSerializer(serializers.ModelSerializer):
 
     label = serializers.CharField(source='__str__', read_only=True)
 
+    related_identifiers = JSONListField(allow_null=True, default=[])
     creators = JSONListField(allow_null=True, default=[])
     contributors = JSONListField(allow_null=True, default=[])
 

--- a/daiquiri/metadata/serializers/datacite.py
+++ b/daiquiri/metadata/serializers/datacite.py
@@ -16,7 +16,7 @@ class DataciteSerializer(serializers.ModelSerializer):
     contributors = JSONListField(default=[])
     language = serializers.ReadOnlyField(default=settings.SITE_LANGUAGE)
     alternate_identifiers = serializers.SerializerMethodField()
-    related_identifiers = serializers.SerializerMethodField() 
+    related_identifiers = JSONListField(default=[]) 
     resource_type = serializers.SerializerMethodField()
     formats = serializers.SerializerMethodField()
     sizes = serializers.SerializerMethodField()
@@ -27,11 +27,6 @@ class DataciteSerializer(serializers.ModelSerializer):
         return obj.published.year if obj.published else None
 
     def get_alternate_identifiers(self, obj):
-        raise NotImplementedError()
-
-    def get_related_identifiers(self, obj):
-        '''Abstract method (should be overwritten by child class)
-        '''
         raise NotImplementedError()
 
     def get_formats(self, obj):
@@ -66,6 +61,7 @@ class DataciteSchemaSerializer(DataciteSerializer):
             'language',
             'resource_type',
             'alternate_identifiers',
+            'related_identifiers',            
             'sizes',
             'formats',
             'license',
@@ -134,14 +130,6 @@ class DataciteTableSerializer(DataciteSerializer):
             'alternate_identifier': url,
             'alternate_identifier_type': 'URL'
         }]
-
-    def get_related_identifiers(self, obj):
-        '''Returns an array of json-like dict with the related_identifiers and their parameters.
-        '''
-        schema_doi = obj.schema.doi
-        return [{'related_identifier': schema_doi,
-                 'related_identifier_type': 'DOI',
-                 'relation_type': 'IsPartOf'}]
 
     def get_sizes(self, obj):
         # filter the columns which are published for the groups of the user


### PR DESCRIPTION
We have been adding `related_identfiers` metadata-entry for Tables and Schemas in order to fill the field in the `DataciteSerializer` for the oai interface. 

1. Added `related_identifiers` as a column in the tables and schemas metadata
2. Added `related_identifiers` in `DataciteSchemaSerializer`
3. Use the `JSONListField` of `daiquiri.core.serializers` to implicitly call `get_related_identifiers` (built-in rest_framework)