### PR TITLE
Add a `workers` management script

### DIFF
--- a/daiquiri/core/management/commands/workers.py
+++ b/daiquiri/core/management/commands/workers.py
@@ -1,0 +1,55 @@
+import subprocess
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('operation', choices=[
+            'start',
+            'stop',
+            'stopwait',
+            'kill',
+            'restart'
+        ])
+
+    def handle(self, *args, **options):
+        queues = [
+            {
+                'node': '{}_default'.format(settings.DAIQUIRI_APP),
+                'queue': 'default',
+                'concurency': 1
+            },
+            {
+                'node': '{}_download'.format(settings.DAIQUIRI_APP),
+                'queue': 'download',
+                'concurency': 1
+            }
+        ] + [{
+            'node': '{}_queue.{}'.format(settings.DAIQUIRI_APP, queue['key']),
+            'queue': 'queue.{}'.format(queue['key']),
+            'concurency': queue.get('concurency', 1)
+        } for queue in settings.QUERY_QUEUES]
+
+        args = ['celery', '-A', 'config', 'multi', options['operation']]
+        args += [queue['node'] for queue in queues]
+
+        if options['operation'] in ['start', 'restart']:
+            for queue in queues:
+                args += [
+                    '-Q:{}'.format(queue['node']), queue['queue'],
+                    '-c:{}'.format(queue['node']), str(queue['concurency'])
+                ]
+
+        args += [
+            '--pidfile={}/%n.pid'.format(settings.CELERY_PIDFILE_PATH),
+            '--loglevel={}'.format(settings.LOG_LEVEL)
+        ]
+        if settings.LOG_DIR:
+            args += [
+                '--logfile={}/%n.log'.format(settings.CELERY_LOG_PATH)
+            ]
+
+        subprocess.call(args)

--- a/daiquiri/core/management/commands/workers.py
+++ b/daiquiri/core/management/commands/workers.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):
@@ -16,6 +16,9 @@ class Command(BaseCommand):
         ])
 
     def handle(self, *args, **options):
+        if not settings.CELERY_PIDFILE_PATH:
+            raise CommandError('CELERY_PIDFILE_PATH is not set')
+
         queues = [
             {
                 'node': '{}_default'.format(settings.DAIQUIRI_APP),
@@ -45,9 +48,9 @@ class Command(BaseCommand):
 
         args += [
             '--pidfile={}/%n.pid'.format(settings.CELERY_PIDFILE_PATH),
-            '--loglevel={}'.format(settings.LOG_LEVEL)
+            '--loglevel={}'.format(settings.CELERY_LOG_LEVEL)
         ]
-        if settings.LOG_DIR:
+        if settings.CELERY_LOG_PATH:
             args += [
                 '--logfile={}/%n.log'.format(settings.CELERY_LOG_PATH)
             ]

--- a/daiquiri/core/settings/django.py
+++ b/daiquiri/core/settings/django.py
@@ -239,3 +239,5 @@ if MEMCACHE_KEY_PREFIX:
     }
 
 CELERY_BROKER_URL = env.get('CELERY_BROKER_URL', 'amqp://')
+CELERY_PIDFILE_PATH = env.get_abspath('CELERY_PIDFILE_PATH')
+CELERY_LOG_PATH = env.get_abspath('CELERY_LOG_PATH')


### PR DESCRIPTION
This PR adds a `workers` management script to operate `celery multi` with the configured queues. Script can be used like this:

```
./manage.py workers start
./manage.py workers stop
./manage.py workers stopwait
./manage.py workers kill
./manage.py workers restart
```

Some settings are added to `.env`:

```
CELERY_PIDFILE_PATH= # mandatory
CELERY_LOG_LEVEL=
CELERY_LOG_PATH=
```