### PR TITLE
Add logout modal to query interface

### DIFF
--- a/daiquiri/core/static/core/css/base.scss
+++ b/daiquiri/core/static/core/css/base.scss
@@ -83,7 +83,11 @@ a,
     &:focus {
         color: $link-color-focus;
     }
-    &.btn {
+    &.btn-primary,
+    &.btn-success,
+    &.btn-info,
+    &.btn-warning,
+    &.btn-danger {
         color: white;
     }
     &.fa {

--- a/daiquiri/query/static/query/js/services/query.js
+++ b/daiquiri/query/static/query/js/services/query.js
@@ -127,6 +127,10 @@ app.factory('QueryService', ['$resource', '$http', '$injector', '$q', '$filter',
 
     service.fetch_status = function() {
         return resources.status.query(function(response) {
+            if (angular.isDefined(service.status) && service.status.guest != response[0].guest) {
+                // the user has been logged out
+                $('#logout-modal').modal('show');
+            }
             service.status = response[0];
         }).$promise;
     };

--- a/daiquiri/query/templates/query/query.html
+++ b/daiquiri/query/templates/query/query.html
@@ -115,5 +115,6 @@
 {% include 'query/query_modal_update_job.html' %}
 {% include 'query/query_modal_abort_job.html' %}
 {% include 'query/query_modal_archive_job.html' %}
+{% include 'query/query_modal_logout.html' %}
 
 {% endblock %}

--- a/daiquiri/query/templates/query/query_modal_logout.html
+++ b/daiquiri/query/templates/query/query_modal_logout.html
@@ -1,0 +1,30 @@
+{% load i18n %}
+
+<div class="modal" id="logout-modal" tabindex="-1" data-backdrop="static" data-keyboard="false">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">
+                    {% trans 'Logout' %}
+                </h4>
+            </div>
+
+            <div class="modal-body">
+                <p>
+                    {% blocktrans trimmed with table_name='{$ service.values.table_name $}' %}
+                    You have been logged out. This happens after a certain time or when you have logged out in another window.
+                    {% endblocktrans %}
+                </p>
+            </div>
+
+            <div class="modal-footer">
+                <a type="button" href="{% url 'query:query' %}" class="btn btn-default">
+                    {% trans 'Continue as guest' %}
+                </a>
+                <a type="button" href="{% url 'account_login' %}?next={% url 'query:query' %}" class="btn btn-primary">
+                    {% trans 'Login' %}
+                </a>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This PR adds a modal to the query interface if the user gets logged out without noticing.

![image](https://user-images.githubusercontent.com/1799675/177755022-1128dcdb-2e37-499a-adee-ae6c23acf7ac.png)
