### PR TITLE
Fix datalink adapter

### DIFF
--- a/daiquiri/datalink/adapter.py
+++ b/daiquiri/datalink/adapter.py
@@ -3,9 +3,9 @@ from django.core.exceptions import ValidationError
 from django.http import Http404
 from django.urls import reverse
 
-from daiquiri.core.constants import ACCESS_LEVEL_PUBLIC
 from daiquiri.core.adapter import DatabaseAdapter
-from daiquiri.core.utils import import_class, get_doi_url
+from daiquiri.core.constants import ACCESS_LEVEL_PUBLIC
+from daiquiri.core.utils import get_doi_url, import_class
 
 from .constants import DATALINK_RELATION_TYPES
 from .models import Datalink
@@ -144,19 +144,21 @@ class MetadataDatalinkAdapterMixin(object):
 
             if schema.related_identifiers:
                 for related_identifier in schema.related_identifiers:
-                    description = DATALINK_RELATION_TYPES.get(related_identifier.get('relation_type'), '') \
-                                                         .format('the {} schema'.format(schema)) \
-                                                         .capitalize()
-                    schema_links.append({
-                       'ID': identifier,
-                       'access_url': related_identifier.get('related_identifier'),
-                       'service_def': '',
-                       'error_message': '',
-                       'description': description,
-                       'semantics': '#auxiliary',
-                       'content_type': 'application/html',
-                       'content_length': None
-                    })
+                    access_url = related_identifier.get('related_identifier')
+                    if access_url is not None:
+                        description = DATALINK_RELATION_TYPES.get(related_identifier.get('relation_type'), '') \
+                                                             .format('the {} schema'.format(schema)) \
+                                                             .capitalize()
+                        schema_links.append({
+                           'ID': identifier,
+                           'access_url': access_url,
+                           'service_def': '',
+                           'error_message': '',
+                           'description': description,
+                           'semantics': '#auxiliary',
+                           'content_type': 'application/html',
+                           'content_length': None
+                        })
 
         return schema_links
 
@@ -204,20 +206,22 @@ class MetadataDatalinkAdapterMixin(object):
 
             if table.related_identifiers:
                 for related_identifier in table.related_identifiers:
-                    description = DATALINK_RELATION_TYPES.get(related_identifier.get('relation_type'), '') \
-                                                         .format('the {} table'.format(table)) \
-                                                         .capitalize()
+                    access_url = related_identifier.get('related_identifier')
+                    if access_url is not None:
+                        description = DATALINK_RELATION_TYPES.get(related_identifier.get('relation_type'), '') \
+                                                             .format('the {} table'.format(table)) \
+                                                             .capitalize()
 
-                    table_links.append({
-                       'ID': identifier,
-                       'access_url': related_identifier.get('related_identifier'),
-                       'service_def': '',
-                       'error_message': '',
-                       'description': description,
-                       'semantics': '#auxiliary',
-                       'content_type': 'application/html',
-                       'content_length': None
-                    })
+                        table_links.append({
+                           'ID': identifier,
+                           'access_url': access_url,
+                           'service_def': '',
+                           'error_message': '',
+                           'description': description,
+                           'semantics': '#auxiliary',
+                           'content_type': 'application/html',
+                           'content_length': None
+                        })
 
         return table_links
 

--- a/daiquiri/oai/adapter.py
+++ b/daiquiri/oai/adapter.py
@@ -6,7 +6,7 @@ from django.utils.timezone import now
 
 from daiquiri.core.adapter import DatabaseAdapter
 from daiquiri.core.constants import ACCESS_LEVEL_PUBLIC
-from daiquiri.core.utils import import_class, get_doi
+from daiquiri.core.utils import get_doi, import_class
 
 
 def OaiAdapter():
@@ -166,17 +166,17 @@ class MetadataOaiAdapterMixin(object):
             for key, values in self.get_datalink(str(instance)).items():
                 try:
                     attr = getattr(instance, key)
-                    if isinstance(key, list):
+                    if isinstance(attr, dict):
                         attr.update(values)
-                    elif isinstance(key, list):
+                    elif isinstance(attr, list):
                         attr += values
                     else:
                         attr = values
                 except AttributeError:
                     attr = values
 
-            # update the instance
-            setattr(instance, key, values)
+                # update the instance
+                setattr(instance, key, attr)
 
         return instance
 


### PR DESCRIPTION
This PR fixes two problems:

* Daiquiri used to crash if a schema/table has `relatedIdentifiers`, but the `related_identifier` value is `null` or missing.
* Related identifiers were ignored for the creation of the DataCite record for OAI, since the (empty) search in the datalink tables overwrite the information in the metadata store.