### PR TITLE
fix html/md render of the column description in the metadata

### DIFF
--- a/daiquiri/metadata/templates/metadata/table.html
+++ b/daiquiri/metadata/templates/metadata/table.html
@@ -66,7 +66,7 @@
                         {{ column.unit|default_if_none:'' }}
                     </td>
                     <td>
-                        {{ column.description|default_if_none:'' }}
+                        {{ column.description | markdown }}
                     </td>
                 </tr>
                 {% endfor %}


### PR DESCRIPTION
From now on, the column description containing html code is rendered correctly in the table overview of the metadata.
`default_if_none:''` is omitted since the new definition requires column.description to be a string, e.g. `""`