### PR TITLE
removed the antlr requirement from daiquiri

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ pytest-django~=4.5.2
 pytest-dotenv~=0.5.2
 pytest-mock~=3.8.2
 pytest-pythonpath~=0.7.4
-queryparser_python3~=0.5.0
+queryparser_python3~=0.6.0
 rules==3.3
 XlsxWriter~=3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # in alphabetical order
-antlr4-python3-runtime==4.8
 astropy~=5.1
 celery~=5.2.3
 coverage~=6.4.2


### PR DESCRIPTION
Antlr is a dependancy of queryparser not daiquiri.