### PR TITLE
fix filter for the access_level INTERNAL

### DIFF
--- a/daiquiri/core/utils.py
+++ b/daiquiri/core/utils.py
@@ -169,7 +169,8 @@ def filter_by_access_level(user, items):
             filtered_items.append(item)
         elif item['access_level'] == ACCESS_LEVEL_INTERNAL:
             if user is not None:
-                filtered_items.append(item)
+                if user.is_authenticated:
+                    filtered_items.append(item)
         elif item['access_level'] == ACCESS_LEVEL_PRIVATE and 'groups' in item:
             if user is not None and user.groups.filter(name__in=item['groups']).exists():
                 filtered_items.append(item)


### PR DESCRIPTION
The queues such as 
```python 
    {
        'key': '5h',
        'label': '5 Hours',
        'timeout': 18000,
        'priority': 1,
        'access_level': 'INTERNAL',
        'groups': []
    },
```
were not filtered out for the not authenticated users. 
With the proposed fix, the filter works correctly.  