### PR TITLE
fix search fields for djago admin

### DIFF
--- a/daiquiri/metadata/admin.py
+++ b/daiquiri/metadata/admin.py
@@ -16,7 +16,7 @@ class TableAdminForm(forms.ModelForm):
 class SchemaAdmin(admin.ModelAdmin):
     form = SchemaAdminForm
 
-    search_fields = ('__str__', )
+    search_fields = ('name',)
     list_display = ('order', '__str__', 'access_level', 'metadata_access_level')
     list_display_links = ('__str__', )
 
@@ -24,13 +24,13 @@ class SchemaAdmin(admin.ModelAdmin):
 class TableAdmin(admin.ModelAdmin):
     form = TableAdminForm
 
-    search_fields = ('__str__', )
+    search_fields = ('name', 'schema__name')
     list_display = ('order', '__str__', 'access_level', 'metadata_access_level')
     list_display_links = ('__str__', )
 
 
 class ColumnAdmin(admin.ModelAdmin):
-    search_fields = ('__str__', 'datatype')
+    search_fields = ('name', 'table__name', 'table__schema__name', 'datatype')
     list_display = ('order', '__str__', 'datatype', 'access_level', 'metadata_access_level')
     list_display_links = ('__str__', )
 

--- a/daiquiri/query/admin.py
+++ b/daiquiri/query/admin.py
@@ -12,13 +12,13 @@ class QueryJobAdmin(JobAdmin):
 
 
 class DownloadJobAdmin(JobAdmin):
-    search_fields = JobAdmin.search_fields + ['schema_name', 'query_job__table_name', 'format_key']
+    search_fields = JobAdmin.search_fields + ['query_job__schema_name', 'query_job__table_name', 'format_key']
     list_display = JobAdmin.list_display + ['query_job', 'file_path']
     actions = ['abort_job', 'archive_job']
 
 
 class QueryArchiveJobAdmin(JobAdmin):
-    search_fields = JobAdmin.search_fields + ['schema_name', 'query_job__table_name', 'format_key']
+    search_fields = JobAdmin.search_fields + ['query_job__schema_name', 'query_job__table_name', 'column_name', 'files']
     list_display = JobAdmin.list_display + ['query_job', 'file_path']
     actions = ['abort_job', 'archive_job']
 


### PR DESCRIPTION
Problem: the search for some models (e.g., `DownloadJobs`) in Django Admin didn't work (internal server error).

Bug: the search fields didn't match the fields of the corresponding model. In some models `__str__` was used as a search field which doesn't seem to work.

Fix: changed the `search_field` accordingly to match the corresponding model