### PR TITLE
add the missing template for the login via socialaccount

### DIFF
--- a/daiquiri/auth/templates/socialaccount/login.html
+++ b/daiquiri/auth/templates/socialaccount/login.html
@@ -1,0 +1,23 @@
+{% extends "core/page.html" %}
+{% load i18n %}
+
+
+{% block page %}
+
+{% if process == "connect" %}
+<h1>{% blocktrans with provider.name as provider %}Connect {{ provider }}{% endblocktrans %}</h1>
+
+<p>{% blocktrans with provider.name as provider %}You are about to connect a new third party account from {{ provider }}.{% endblocktrans %}</p>
+{% else %}
+<h1>{% blocktrans with provider.name as provider %}Sign In Via {{ provider }}{% endblocktrans %}</h1>
+
+<p>{% blocktrans with provider.name as provider %}You are about to sign in using a third party account from {{ provider }}.{% endblocktrans %}</p>
+{% endif %}
+
+<form method="post">
+  {% csrf_token %}
+  <button type="submit">{% trans "Continue" %}</button>
+</form>
+{% endblock %}
+Footer
+


### PR DESCRIPTION
Currently, daiquiri uses the standard template from django-allauth, which doesn't  use the styling of the website. For instance, see https://gaia.aip.de/accounts/google/login/?process=login. 

This PR adds a simple login template for the redirection  to the third party websites, which uses the styling of the website.
