### PR TITLE
BUG: valid unicodeChar column type is not supported

### DIFF
--- a/daiquiri/core/adapter/database/base.py
+++ b/daiquiri/core/adapter/database/base.py
@@ -201,6 +201,12 @@ class BaseDatabaseAdapter(object):
             self.execute(sql)
 
     def create_table(self, schema_name, table_name, columns):
+
+        # check column types
+        for column in columns:
+            if self.COLUMNTYPES.get(column['datatype'], None) is None:
+                raise TypeError("Column {name} is of type {datatype}. {datatype} is not supported by Postgres, the table can not be created.".format(datatype = column['datatype']))
+
         # prepare sql string
         sql = 'CREATE TABLE %(schema)s.%(table)s (%(columns)s);' % {
             'schema': self.escape_identifier(schema_name),

--- a/daiquiri/core/adapter/database/postgres.py
+++ b/daiquiri/core/adapter/database/postgres.py
@@ -76,12 +76,17 @@ class PostgreSQLAdapter(BaseDatabaseAdapter):
 
     COLUMNTYPES = {
         'char': 'text',
+        'unicodeChar': 'text',
         'boolean': 'boolean',
+        'bit': 'boolean',
+        # 'unsignedByte': ???, not supported by Postgres... could be solved with pguint extention
         'short': 'smallint',
         'int': 'integer',
         'long': 'bigint',
         'float': 'real',
         'double': 'double precision'
+        #'floatComplex': ???, not supported by Postgres
+        #'doubleComplex': ???, not supported by Postgres
     }
 
     search_stmt_template = '%s::text LIKE %%s'


### PR DESCRIPTION
added missing compatible types between VOTable and Postgres and raised an error in case an unsupported type is provided