### PR TITLE
Validator for Creators and Contributors

### DIFF
--- a/daiquiri/metadata/serializers/__init__.py
+++ b/daiquiri/metadata/serializers/__init__.py
@@ -5,6 +5,7 @@ from daiquiri.core.serializers import JSONListField
 
 from rest_framework import serializers
 
+from .validators import PersonListValidator
 from ..models import Schema, Table, Column, Function
 
 
@@ -60,8 +61,8 @@ class TableSerializer(serializers.ModelSerializer):
     label = serializers.CharField(source='__str__', read_only=True)
 
     related_identifiers = JSONListField(required=False)
-    creators = JSONListField(required=False)
-    contributors = JSONListField(required=False)
+    creators = JSONListField(required=False, validators=[PersonListValidator()])
+    contributors = JSONListField(required=False, validators=[PersonListValidator()])
     license = serializers.ChoiceField(choices=settings.LICENSE_CHOICES, default='')
 
     class Meta:
@@ -74,8 +75,8 @@ class SchemaSerializer(serializers.ModelSerializer):
     label = serializers.CharField(source='__str__', read_only=True)
 
     related_identifiers = JSONListField(required=False)
-    creators = JSONListField(required=False)
-    contributors = JSONListField(required=False)
+    creators = JSONListField(required=False, validators=[PersonListValidator()])
+    contributors = JSONListField(required=False, validators=[PersonListValidator()])
     license = serializers.ChoiceField(choices=settings.LICENSE_CHOICES, default='', initial='')
 
     class Meta:

--- a/daiquiri/metadata/serializers/validators.py
+++ b/daiquiri/metadata/serializers/validators.py
@@ -1,0 +1,31 @@
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework.exceptions import ValidationError
+
+class PersonListValidator(object):
+
+    def __call__(self, persons):
+
+        for person in persons:
+
+            if not isinstance(person, dict):
+                raise ValidationError("the person field must be a JSON Field")
+      
+            affiliations = person.get("affiliations", [])
+
+            if isinstance(affiliations, list):
+                for affiliation in affiliations:
+                
+                    if isinstance(affiliation, dict):
+                        if affiliation != {}: # if not empty dict should have at least affiliation name
+                            affiliation_name = affiliation.get("affiliation", None)
+
+                            if affiliation_name is None:
+                                raise ValidationError('affiliation needs at least a name: "affiliation": <name>')
+                        else:
+                            raise ValidationError("empty affiliations are not valid")
+                    else:
+                        raise ValidationError("each affiliation must be a JSON field")
+
+            else:
+                raise ValidationError("affiliations must be a list of JSON Fields")


### PR DESCRIPTION
added a validator for `metadata.TableSerializer` and `metadata.SchemaSerializer` for validation the content of the JSON fields `creators` and `contributors`. In particular validation of the format of affiliations key.