### PR TITLE
remove affiliations from the frontend

### DIFF
--- a/daiquiri/metadata/static/metadata/js/metadata.js
+++ b/daiquiri/metadata/static/metadata/js/metadata.js
@@ -66,8 +66,7 @@ angular.module('metadata', ['core'])
                 name: '',
                 first_name: '',
                 last_name: '',
-                orcid: '',
-                affiliations: ''
+                orcid: ''
             }
         }
     };

--- a/daiquiri/metadata/templates/metadata/management_modal_form_schemas_contributors.html
+++ b/daiquiri/metadata/templates/metadata/management_modal_form_schemas_contributors.html
@@ -18,40 +18,34 @@
 
                         <div class="row">
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'Name' %}"
                                 data-model="contributor.name">
                             </formgroup>
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'First name' %}"
                                 data-model="contributor.first_name">
                             </formgroup>
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'Last name' %}"
                                 data-model="contributor.last_name">
                             </formgroup>
+                        </div>
+                        <div class="row">
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'ORCID' %}"
                                 data-model="contributor.orcid">
                             </formgroup>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-9">
-                               <formgroup
-                                    data-type="textareasplit"
-                                    data-label="{% trans 'Affiliations' %}"
-                                    data-help="{% trans 'Seperate multiple affiliations by newlines' %}"
-                                    data-model="contributor.affiliations">
-                                </formgroup>
+                            <div class="col-md-4">
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-4">
                                 <button type="button" class="btn btn-danger form-inline-button"
                                     ng-click="service.removePerson('contributors', $index)">
 

--- a/daiquiri/metadata/templates/metadata/management_modal_form_schemas_creators.html
+++ b/daiquiri/metadata/templates/metadata/management_modal_form_schemas_creators.html
@@ -18,40 +18,34 @@
 
                         <div class="row">
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'Name' %}"
                                 data-model="creator.name">
                             </formgroup>
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'First name' %}"
                                 data-model="creator.first_name">
                             </formgroup>
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'Last name' %}"
                                 data-model="creator.last_name">
                             </formgroup>
+                        </div>
+                        <div class="row">
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'ORCID' %}"
                                 data-model="creator.orcid">
                             </formgroup>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-9">
-                               <formgroup
-                                    data-type="textareasplit"
-                                    data-label="{% trans 'Affiliations' %}"
-                                    data-help="{% trans 'Seperate multiple affiliations by newlines' %}"
-                                    data-model="creator.affiliations">
-                                </formgroup>
+                            <div class="col-md-4">
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-4">
                                 <button type="button" class="btn btn-danger form-inline-button"
                                     ng-click="service.removePerson('creators', $index)">
 

--- a/daiquiri/metadata/templates/metadata/management_modal_form_tables_contributors.html
+++ b/daiquiri/metadata/templates/metadata/management_modal_form_tables_contributors.html
@@ -18,40 +18,34 @@
 
                         <div class="row">
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'Name' %}"
                                 data-model="contributor.name">
                             </formgroup>
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'First name' %}"
                                 data-model="contributor.first_name">
                             </formgroup>
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'Last name' %}"
                                 data-model="contributor.last_name">
                             </formgroup>
+                        </div>
+                        <div class="row">
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'ORCID' %}"
                                 data-model="contributor.orcid">
                             </formgroup>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-9">
-                               <formgroup
-                                    data-type="textareasplit"
-                                    data-label="{% trans 'Affiliations' %}"
-                                    data-help="{% trans 'Seperate multiple affiliations by newlines' %}"
-                                    data-model="contributor.affiliations">
-                                </formgroup>
+                            <div class="col-md-4">
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-4">
                                 <button type="button" class="btn btn-danger form-inline-button"
                                     ng-click="service.removePerson('contributors', $index)">
 

--- a/daiquiri/metadata/templates/metadata/management_modal_form_tables_creators.html
+++ b/daiquiri/metadata/templates/metadata/management_modal_form_tables_creators.html
@@ -18,40 +18,34 @@
 
                         <div class="row">
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'Name' %}"
                                 data-model="creator.name">
                             </formgroup>
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'First name' %}"
                                 data-model="creator.first_name">
                             </formgroup>
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'Last name' %}"
                                 data-model="creator.last_name">
                             </formgroup>
+                        </div>
+                        <div class="row">
                             <formgroup
-                                class="col-md-3"
+                                class="col-md-4"
                                 data-type="text"
                                 data-label="{% trans 'ORCID' %}"
                                 data-model="creator.orcid">
                             </formgroup>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-9">
-                               <formgroup
-                                    data-type="textareasplit"
-                                    data-label="{% trans 'Affiliations' %}"
-                                    data-help="{% trans 'Seperate multiple affiliations by newlines' %}"
-                                    data-model="creator.affiliations">
-                                </formgroup>
+                            <div class="col-md-4">
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-4">
                                 <button type="button" class="btn btn-danger form-inline-button"
                                     ng-click="service.removePerson('creators', $index)">
 


### PR DESCRIPTION
The input form for affiliations is removed from the metadata management to ensure the compatibility with REST API Currently, affiliations are stored in a list of dictionaries while the frontend expects a list of strings. 