### PR TITLE
add ror id to the datacite metadata

### DIFF
--- a/daiquiri/core/renderers/datacite.py
+++ b/daiquiri/core/renderers/datacite.py
@@ -139,6 +139,13 @@ class DataciteRendererMixin(object):
                     'nameIdentifierScheme': 'ORCID'
                 }, orcid)
 
+            ror = person.get('ror')
+            if ror:
+                self.node('nameIdentifier', {
+                    'schemeURI': 'http://ror.org/',
+                    'nameIdentifierScheme': 'ROR'
+                }, ror)
+
             affiliations = person.get('affiliations')
             if affiliations:
                 for affiliation in affiliations:


### PR DESCRIPTION
The ROR identifier is added to the OAI metadata renderer which is very useful for the creators/collaborators that are organizations. 