### PR TITLE
Hotfix sync queries

### DIFF
--- a/daiquiri/metadata/serializers/__init__.py
+++ b/daiquiri/metadata/serializers/__init__.py
@@ -5,6 +5,7 @@ from daiquiri.core.serializers import JSONListField
 
 from rest_framework import serializers
 
+from .validators import PersonListValidator
 from ..models import Schema, Table, Column, Function
 
 
@@ -60,8 +61,8 @@ class TableSerializer(serializers.ModelSerializer):
     label = serializers.CharField(source='__str__', read_only=True)
 
     related_identifiers = JSONListField(required=False)
-    creators = JSONListField(required=False)
-    contributors = JSONListField(required=False)
+    creators = JSONListField(required=False, validators=[PersonListValidator()])
+    contributors = JSONListField(required=False, validators=[PersonListValidator()])
     license = serializers.ChoiceField(choices=settings.LICENSE_CHOICES, default='')
 
     class Meta:
@@ -74,8 +75,8 @@ class SchemaSerializer(serializers.ModelSerializer):
     label = serializers.CharField(source='__str__', read_only=True)
 
     related_identifiers = JSONListField(required=False)
-    creators = JSONListField(required=False)
-    contributors = JSONListField(required=False)
+    creators = JSONListField(required=False, validators=[PersonListValidator()])
+    contributors = JSONListField(required=False, validators=[PersonListValidator()])
     license = serializers.ChoiceField(choices=settings.LICENSE_CHOICES, default='', initial='')
 
     class Meta:

--- a/daiquiri/metadata/serializers/validators.py
+++ b/daiquiri/metadata/serializers/validators.py
@@ -1,0 +1,31 @@
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework.exceptions import ValidationError
+
+class PersonListValidator(object):
+
+    def __call__(self, persons):
+
+        for person in persons:
+
+            if not isinstance(person, dict):
+                raise ValidationError("the person field must be a JSON Field")
+      
+            affiliations = person.get("affiliations", [])
+
+            if isinstance(affiliations, list):
+                for affiliation in affiliations:
+                
+                    if isinstance(affiliation, dict):
+                        if affiliation != {}: # if not empty dict should have at least affiliation name
+                            affiliation_name = affiliation.get("affiliation", None)
+
+                            if affiliation_name is None:
+                                raise ValidationError('affiliation needs at least a name: "affiliation": <name>')
+                        else:
+                            raise ValidationError("empty affiliations are not valid")
+                    else:
+                        raise ValidationError("each affiliation must be a JSON field")
+
+            else:
+                raise ValidationError("affiliations must be a list of JSON Fields")

--- a/daiquiri/query/process.py
+++ b/daiquiri/query/process.py
@@ -215,9 +215,9 @@ def process_display_columns(processor_display_columns):
     for processor_display_column, original_column in processor_display_columns:
         if processor_display_column == '*':
             schema_name, table_name, tmp = original_column
-            for column_name in DatabaseAdapter().fetch_column_names(schema_name, table_name):
-                display_columns.append((column_name, (schema_name, table_name, column_name)))
-
+            columns = Column.objects.filter(table__schema__name=schema_name).filter(table__name=table_name).order_by('order')
+            for column in columns:
+                display_columns.append((column.name, (schema_name, table_name, column.name)))
         else:
             display_columns.append((processor_display_column, original_column))
 


### PR DESCRIPTION
The order of the columns in case of `SELECT *` and `sync` queries were depending on the ingestion order of the columns (kind of random).

We correct that in ordering the columns according to the order metadata information.