### PR TITLE
Dynamic datalink

### DIFF
--- a/daiquiri/datalink/adapter.py
+++ b/daiquiri/datalink/adapter.py
@@ -94,7 +94,7 @@ class BaseDatalinkAdapter(object):
                 link['description'],
                 link['semantics'],
                 link['content_type'],
-                link['content_size']) for link in self.get_dyn_datalink_links(identifiers)
+                link['content_length']) for link in self.get_dyn_datalink_links(identifiers)
             ]
 
         # in case of malformation give some hints to the developper

--- a/daiquiri/datalink/adapter.py
+++ b/daiquiri/datalink/adapter.py
@@ -85,7 +85,27 @@ class BaseDatalinkAdapter(object):
         rows = list(Datalink.objects.filter(ID__in=identifiers).values_list(*field_names))
 
         # get the dynamic datalink entries
-        dyn_rows = [tuple(link.values()) for link in self.get_dyn_datalink_links(identifiers)]
+        try:
+            dyn_rows = [(
+                link['ID'],
+                link['access_url'],
+                link['service_def'],
+                link['error_message'],
+                link['description'],
+                link['semantics'],
+                link['content_type'],
+                link['content_size']) for link in self.get_dyn_datalink_links(identifiers)
+            ]
+
+        # in case of malformation give some hints to the developper
+        except KeyError as e:
+            class_name = str(self.__class__)
+            raise KeyError(f"The key '{e.args[0]}' is missing in one of the dictionaries returned by {class_name}.get_dyn_datalink_links(id)")
+
+        # otherwise just raise
+        except Exception as e:
+            raise e
+
         rows = rows + dyn_rows
 
         # check for missing IDs and return error message

--- a/daiquiri/datalink/adapter.py
+++ b/daiquiri/datalink/adapter.py
@@ -54,6 +54,8 @@ class BaseDatalinkAdapter(object):
                     raise NotImplementedError(message)
 
     def get_list(self):
+        '''This is only used by rebuild_datalink_table, so it needs to gather only the tabular datalink entries.
+        '''
         for resource_type in self.resource_types:
             yield from getattr(self, 'get_%s_list' % resource_type)()
 
@@ -77,7 +79,7 @@ class BaseDatalinkAdapter(object):
         return context
 
     def get_datalink_rows(self, identifiers, **kwargs):
-        '''Get the list of datalink entries for the provided identifiers
+        '''Get the list of datalink entries for the provided identifiers (incl. table- and dynamic- datalink)
         '''
 
         # get the datalink entries from Datalink Table and metadata (Table and Schema)

--- a/daiquiri/datalink/adapter.py
+++ b/daiquiri/datalink/adapter.py
@@ -7,7 +7,7 @@ from daiquiri.core.adapter import DatabaseAdapter
 from daiquiri.core.constants import ACCESS_LEVEL_PUBLIC
 from daiquiri.core.utils import get_doi_url, import_class
 
-from .constants import DATALINK_RELATION_TYPES
+from .constants import DATALINK_RELATION_TYPES, DATALINK_FIELDS
 from .models import Datalink
 
 
@@ -29,6 +29,14 @@ class BaseDatalinkAdapter(object):
 
     * get_<resource_type>_links(self, resource): returns a resource into a list
       of rows of the datalink table (list of python dicts)
+
+    There are two further adapters, which do not declare resources:
+
+    * DynamicDatalinkAdapter: the latter does not declare a resource, but will inject on the fly 
+      extra datalink entries according to the method: get_dyn_datalink_links()
+
+    * QueryJobDatalinkAdapterMixin: The latter does not declare a resource either, but it injects 
+      extra context information for the datalink viewer.
 
     See the mixins below for an example.
     """
@@ -56,13 +64,37 @@ class BaseDatalinkAdapter(object):
         return getattr(self, 'get_%s_links' % resource_type)(resource)
 
     def get_context_data(self, request, **kwargs):
+        '''Get the datalink related context data for a given request
+        '''
         context = {}
 
         if 'ID' in kwargs:
-            context['datalinks'] = Datalink.objects.filter(ID=kwargs['ID']).order_by('semantics')
+            field_names = [field['name'] for field in DATALINK_FIELDS]
+            # more precise would be to use a serializer instead of list(QuerySet.values())
+            context['datalinks'] = list(Datalink.objects.filter(ID=kwargs['ID']).order_by('semantics').values())
             context['ID'] = kwargs['ID']
 
         return context
+
+    def get_datalink_rows(self, identifiers, **kwargs):
+        '''Get the list of datalink entries for the provided identifiers
+        '''
+
+        # get the datalink entries from Datalink Table and metadata (Table and Schema)
+        field_names = [field['name'] for field in DATALINK_FIELDS]
+        rows = list(Datalink.objects.filter(ID__in=identifiers).values_list(*field_names))
+
+        # get the dynamic datalink entries
+        dyn_rows = [tuple(link.values()) for link in self.get_dyn_datalink_links(identifiers)]
+        rows = rows + dyn_rows
+
+        # check for missing IDs and return error message
+        for identifier in identifiers:
+            if not any(filter(lambda row: row[0] == identifier, rows)):
+                rows.append((identifier, None, None, 'NotFoundFault: {}'.format(identifier), None, None, None, None))        
+
+        return rows
+        
 
 
 class TablesDatalinkAdapterMixin(object):
@@ -226,6 +258,29 @@ class MetadataDatalinkAdapterMixin(object):
         return table_links
 
 
+class DynamicDatalinkAdapterMixin(object):
+    '''Define the interface to dynamically add datalink entries
+    '''
+
+    def get_dyn_datalink_links(self, IDs, **kwargs):
+        '''No dynamically generated entries. Can be overwriten.
+
+        this method should return a list of dict with the following keys:
+             ID, access_url, service_def, error_message, description, semantics, content_type, content_length
+        '''
+        return([])
+
+    def get_context_data(self, request, **kwargs):
+        '''Inject dynamically generated Datalink entries into the context for the daiquiri.datalinks.views.datalink View
+        '''
+        context = super().get_context_data(request, **kwargs)
+
+        if 'ID' in kwargs:
+            context['datalinks'] = context['datalinks'] + self.get_dyn_datalink_links([kwargs['ID']], **kwargs)
+
+        return context
+
+
 class QueryJobDatalinkAdapterMixin(object):
     '''
     Injects the query job into the context data for the daiquiri.datalinks.views.datalink view
@@ -244,8 +299,8 @@ class QueryJobDatalinkAdapterMixin(object):
 
         return context
 
-
-class DefaultDatalinkAdapter(MetadataDatalinkAdapterMixin,
+class DefaultDatalinkAdapter(DynamicDatalinkAdapterMixin,
+                             MetadataDatalinkAdapterMixin,
                              TablesDatalinkAdapterMixin,
                              QueryJobDatalinkAdapterMixin,
                              BaseDatalinkAdapter):

--- a/daiquiri/oai/adapter.py
+++ b/daiquiri/oai/adapter.py
@@ -220,15 +220,15 @@ class DatalinkOAIAdapterMixin(object):
         return import_class('daiquiri.datalink.serializers.DataciteSerializer')
 
     def get_datalink_list(self):
+        '''This function is used by rebuild_oai_schema only, it only needs to gather the doi objects declared via datalink (no other entries).
+        '''
+        for table in self.tables:
+            schema_name, table_name = table.split('.')
+            rows = DatabaseAdapter().fetch_rows(schema_name, table_name, column_names=['ID', 'access_url'],
+                                                page_size=0, filters={'semantics': '#doi'})
 
-        adapter = DatalinkAdapter()
-        # get all datalink entries: DatalinkTables, Metadata and Dynamic
-        rows = adapter.get_datalink_rows([pk])
-    
-        for ID, access_url, _, _, _, semantics, _, _ in rows:
-            if semantics == '#doi':
+            for ID, access_url in rows:
                 yield 'datalink', {'id': str(ID), 'doi': get_doi(access_url)}
-            
 
     def get_datalink(self, pk):
     

--- a/daiquiri/query/utils.py
+++ b/daiquiri/query/utils.py
@@ -240,7 +240,7 @@ def get_job_column(job, display_column_name):
 def get_job_columns(job):
     columns = []
 
-    if job.phase == job.PHASE_COMPLETED:
+    if job.phase == job.PHASE_COMPLETED or job.job_type == job.JOB_TYPE_SYNC:
         database_columns = DatabaseAdapter().fetch_columns(job.schema_name, job.table_name)
 
         for database_column in database_columns:


### PR DESCRIPTION
# This is the first attempt to create dynamic datalink.

## Why dynamic datalink?

making use of tables for datalink is useful since it allows more flexibility (for non-programmable entries) and it is easier to maintain.

Additionally the datalink entries are usually part of the release, and as such get a DOI. 

However, in one cases making use of tables to provide datalink entries may not be confortable:
* in case of too many entries: like in Gaia, several datalink entries per source_id (same for applause...)

In these cases datalink entries generated on the fly based on the ID are necessary.

## Implementation

I added a DynamicDatalinkAdapterMixin class that take care of the dynamic datalink entries. I also added a method called: `get_datalink_rows` and `get_dyn_datalink_links` to the `BaseDatalinkAdapter`, to provide a single point of gathering for the datalink entries (slighlty slower). 

This improve greatly the maintenance and flexibility.

These changes should not break the former functionality.

## How to

With this new implementation it is possible to add new datalink entries by overwriting the method:

`get_dyn_datalink_links` from the DatalinkAdapter. This method returns a list of dynamic datalink entries for the provided IDs. The user is free of implementing anything necessary. It just need to declare the new DatalinkAdapter in `settings/base.py`

## Improvements

This pull request also solves some issues the previous implementation had:
1. There were various place in the code where the datalink data were gathered, making maintenance difficult
2. There were no flexibility in the way OAI and Datalink were connected (now there is an adapter).