### PR TITLE
Fix the datalink #doi entry

### DIFF
--- a/daiquiri/datalink/adapter.py
+++ b/daiquiri/datalink/adapter.py
@@ -190,7 +190,7 @@ class MetadataDatalinkAdapterMixin(object):
                    'access_url': get_doi_url(schema.doi),
                    'service_def': '',
                    'error_message': '',
-                   'description': 'Digital object identifier (DOI) for the {} schema'.format(schema),
+                   'description': '{}'.format(schema.title),
                    'semantics': '#doi',
                    'content_type': 'application/html',
                    'content_length': None
@@ -252,7 +252,7 @@ class MetadataDatalinkAdapterMixin(object):
                    'access_url': get_doi_url(table.doi),
                    'service_def': '',
                    'error_message': '',
-                   'description': 'Digital object identifier (DOI) for the {} table'.format(table),
+                   'description': '{}'.format(table.title),
                    'semantics': '#doi',
                    'content_type': 'application/html',
                    'content_length': None


### PR DESCRIPTION
This PR changes the description of the datalink entruies with the semantic `#doi`. Instead of `The Digital Object Identifier for the ...`, it will use the title of the table/schema obtained from the `metadata`. It is clear that it refers to the DOI of the given object due to the used semantic `#doi` anyway, thus the explicit mentioning of the DOI in the description is obsolete. 
This change is due to the fact that the OAI-PMH interface uses the description of the `#doi` entry as `title` for the OAI record. It's wrong since the OAI record refers to the object itself and not to the DOI. 

Optional tasks:

- [ ] add the description page for the custom semantics (currently `#doi` only)
- [ ]  in the datalink viewer, resolve the semantics as links to the description