### PR TITLE
Fix tap for the chunked transfer encoding

### DIFF
--- a/daiquiri/core/utils.py
+++ b/daiquiri/core/utils.py
@@ -15,7 +15,7 @@ from django.contrib.auth.models import Group, Permission, User
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.db.models import Q
-from django.http import HttpResponse
+from django.http import HttpResponse, QueryDict
 from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.utils.timezone import localtime
@@ -179,33 +179,38 @@ def filter_by_access_level(user, items):
     return filtered_items
 
 
-def human2bytes(string):
+def human2bytes(string: str)-> int:
     if not string:
         return 0
 
     m = re.match(r'([0-9.]+)\s*([A-Za-z]+)', string)
+    if m is None:
+        raise ValueError("Input string is not in the expected format")
+
     number, unit = float(m.group(1)), m.group(2).strip().lower()
 
     if unit == 'kb' or unit == 'k':
-        return number * 1000
+        return int(number * 1000)
     elif unit == 'mb' or unit == 'm':
-        return number * 1000**2
+        return int(number * 1000**2)
     elif unit == 'gb' or unit == 'g':
-        return number * 1000**3
+        return int(number * 1000**3)
     elif unit == 'tb' or unit == 't':
-        return number * 1000**4
+        return int(number * 1000**4)
     elif unit == 'pb' or unit == 'p':
-        return number * 1000**5
+        return int(number * 1000**5)
     elif unit == 'kib':
-        return number * 1024
+        return int(number * 1024)
     elif unit == 'mib':
-        return number * 1024**2
+        return int(number * 1024**2)
     elif unit == 'gib':
-        return number * 1024**3
+        return int(number * 1024**3)
     elif unit == 'tib':
-        return number * 1024**4
+        return int(number * 1024**4)
     elif unit == 'pib':
-        return number * 1024**5
+        return int(number * 1024**5)
+    else:
+        raise ValueError(f"Unrecognized unit: {unit}")
 
 
 def markdown(md):
@@ -223,19 +228,14 @@ def markdown(md):
 
 
 def make_query_dict_upper_case(input_dict):
-    output_dict = input_dict.copy()
+    output_dict = QueryDict(mutable=True)
 
-    for key in input_dict.keys():
-        if key.upper() != key:
-            values = output_dict.getlist(key)
-
-            if key.upper() in output_dict:
-                output_dict.appendlist(key.upper(), values)
-            else:
-                output_dict.setlist(key.upper(), values)
-
-            output_dict.pop(key)
-
+    for key, values in input_dict.lists():
+        uppercase_key = key.upper()
+        if uppercase_key in output_dict:
+            output_dict.appendlist(uppercase_key, values)
+        else:
+            output_dict.setlist(uppercase_key, values)
     return output_dict
 
 

--- a/daiquiri/tap/middleware.py
+++ b/daiquiri/tap/middleware.py
@@ -1,0 +1,12 @@
+from django.utils.deprecation import MiddlewareMixin
+from daiquiri.query.utils import get_quota
+
+class ChunkedTransferMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        if 'HTTP_TRANSFER_ENCODING' in request.META \
+                and request.META['HTTP_TRANSFER_ENCODING'] == 'chunked' \
+                and request.path.startswith('/tap/'):
+            upload_quota = get_quota(request.user, 'QUERY_UPLOAD_LIMIT')
+            request.META["CONTENT_LENGTH"] = upload_quota
+            request._stream.limit = upload_quota
+

--- a/daiquiri/tap/settings.py
+++ b/daiquiri/tap/settings.py
@@ -1,8 +1,13 @@
 import daiquiri.core.env as env
+from daiquiri.core.settings.django import MIDDLEWARE
 
 TAP_SCHEMA = env.get('TAP_SCHEMA', 'tap_schema')
 TAP_UPLOAD = env.get('TAP_UPLOAD', 'tap_upload')
 
 TAP_SUBJECTS = [
     'tap'
+]
+
+MIDDLEWARE =  MIDDLEWARE + [
+    'daiquiri.tap.middleware.ChunkedTransferMiddleware',
 ]


### PR DESCRIPTION
This PR fixes the issue Daiquri had with TOPCAT. It was impossible to use the TAP_UPLOAD feature because TOPCAT is sending chunked request which was not supported in Daiquiri. 

For now I limited the fix only to the request sent to  `/tap/...`  to avoid any surprises for other modules. 

One important caveat of this fix - it only works with gunicorn because it provides access to the de-chunked body of the request. It doesn't work with the Django development server and I'm not sure about the compatibility with other servers.

Along with the changes in tap, I refactored some other code:
 - `human2bytes` returns only an integer (before it was float, Literal,  None) or raises an exception 
 - `make_query_dict_upper_case` uses a mutable QueryDict instead of copying the dict. There was an issue with copying if the request was bigger than 2.5 MB. 
 
 
 I'm not 100% happy with the solution since it requires gunicorn but for now I don't have anything better in mind. I'm open to suggestions.