### PR TITLE
Fix db browser

### DIFF
--- a/daiquiri/metadata/assets/js/components/Management.js
+++ b/daiquiri/metadata/assets/js/components/Management.js
@@ -38,8 +38,8 @@ const Management = () => {
   const handleModal = (type) => {
     setValues({
       type,
-      schema: isEmpty(schemas) ? null : schemas[0].id,
-      table: (isEmpty(schemas) || isEmpty(schemas[0].tables)) ? null : schemas[0].tables[0].id,
+      schema: activeItem.type == 'schema' ? activeItem.id : (isEmpty(schemas)? null : schemas[0].id),
+      table: (isEmpty(schemas) || isEmpty(schemas[0].tables)) ? null : (activeItem.type == 'table' ? activeItem.id : schemas[0].tables[0].id),
       query_string: '',
       discover: true
     })

--- a/daiquiri/metadata/assets/js/components/Management.js
+++ b/daiquiri/metadata/assets/js/components/Management.js
@@ -38,8 +38,8 @@ const Management = () => {
   const handleModal = (type) => {
     setValues({
       type,
-      schema: activeItem.type == 'schema' ? activeItem.id : (isEmpty(schemas)? null : schemas[0].id),
-      table: (isEmpty(schemas) || isEmpty(schemas[0].tables)) ? null : (activeItem.type == 'table' ? activeItem.id : schemas[0].tables[0].id),
+      schema: isEmpty(schemas) ? null : (activeItem?.type == 'schema' ? activeItem.id : schemas[0].id),
+      table: (isEmpty(schemas) || isEmpty(schemas[0].tables)) ? null : (activeItem?.type == 'table' ? activeItem.id : schemas[0].tables[0].id),
       query_string: '',
       discover: true
     })

--- a/daiquiri/metadata/assets/js/components/Schemas.js
+++ b/daiquiri/metadata/assets/js/components/Schemas.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { isEmpty, isNil } from 'lodash'
@@ -11,6 +11,9 @@ const Schemas = ({ schemas, activeItem, setActiveItem, getTooltip, onDoubleClick
   const [visibleSchemas, setVisibleSchemas] = useState([])
   const [visibleTables, setVisibleTables] = useState([])
   const [visibleColumns, setVisibleColumns] = useState([])
+
+  const refListTables = useRef(null)
+  const refListColumns = useRef(null)
 
   const initBrowser = () => {
     if (!isEmpty(schemas)) {
@@ -44,7 +47,13 @@ const Schemas = ({ schemas, activeItem, setActiveItem, getTooltip, onDoubleClick
         }
 
         setOpenTable(table)
+        if (refListTables.current) {
+            refListTables.current.scrollTop = 0
+        }
         setVisibleColumns((isNil(table) || isNil(table.columns)) ? [] : table.columns)
+        if (refListColumns.current) {
+            refListColumns.current.scrollTop = 0
+        }
 
       } else if (activeItem.type == 'table') {
         // search for the table
@@ -56,6 +65,9 @@ const Schemas = ({ schemas, activeItem, setActiveItem, getTooltip, onDoubleClick
         if (table) {
           setOpenTable(table)
           setVisibleColumns(table.columns)
+          if (refListColumns.current) {
+              refListColumns.current.scrollTop = 0
+          }
         }
 
       }
@@ -111,7 +123,7 @@ const Schemas = ({ schemas, activeItem, setActiveItem, getTooltip, onDoubleClick
             <div className="dq-browser-title">
               {gettext('Tables')}
             </div>
-            <ul className="dq-browser-list">
+            <ul className="dq-browser-list" ref={refListTables}>
               {
                 visibleTables.map((table, index) => (
                   <li key={index}>
@@ -138,7 +150,7 @@ const Schemas = ({ schemas, activeItem, setActiveItem, getTooltip, onDoubleClick
             <div className="dq-browser-title">
               {gettext('Columns')}
             </div>
-            <ul className="dq-browser-list">
+            <ul className="dq-browser-list" ref={refListColumns}>
               {
                 visibleColumns.map((column, index) => (
                   <li key={index}>

--- a/daiquiri/metadata/assets/js/components/Schemas.js
+++ b/daiquiri/metadata/assets/js/components/Schemas.js
@@ -136,7 +136,7 @@ const Schemas = ({ schemas, activeItem, setActiveItem, getTooltip, onDoubleClick
                       >
                         <div>{schema.name}</div>
                         {
-                          openSchema && (openSchema.id == schema.id) && (
+                          openSchema && (isEqual(openSchema, schema)) && (
                             <div className="ms-auto"><i className="bi bi-chevron-right"></i></div>
                           )
                         }
@@ -163,7 +163,7 @@ const Schemas = ({ schemas, activeItem, setActiveItem, getTooltip, onDoubleClick
                       >
                         <div>{table.name}</div>
                         {
-                          openTable && (openTable.id == table.id) && (
+                          openTable && (isEqual(openTable, table)) && (
                             <div className="ms-auto"><i className="bi bi-chevron-right"></i></div>
                           )
                         }

--- a/daiquiri/metadata/assets/js/components/Schemas.js
+++ b/daiquiri/metadata/assets/js/components/Schemas.js
@@ -47,38 +47,17 @@ const Schemas = ({ schemas, activeItem, setActiveItem, getTooltip, onDoubleClick
         setVisibleColumns((isNil(table) || isNil(table.columns)) ? [] : table.columns)
 
       } else if (activeItem.type == 'table') {
-        // search for the schema and table
-        const [schema, table] = schemas.reduce((result, schema) => {
+        // search for the table
+        const table = schemas.reduce((result, schema) => {
           const table = (schema.tables || []).find(t => isEqual(t, activeItem))
-          return isNil(table) ? result : [schema, table]
-        }, [])
-
-        if (schema) {
-          setOpenSchema(schema)
-          setVisibleTables(schema.tables)
-        }
+          return isNil(table) ? result : table
+        }, null )
 
         if (table) {
           setOpenTable(table)
           setVisibleColumns(table.columns)
         }
 
-      } else if (activeItem.type == 'column') {
-        // search for the schema and the table for the column
-        const [schema, table] = schemas.reduce((result, schema) => {
-          const table = (schema.tables || []).find(t => (t.columns && t.columns.find(c => isEqual(c, activeItem))))
-          return isNil(table) ? result : [schema, table]
-        }, [])
-
-        if (schema) {
-          setOpenSchema(schema)
-          setVisibleTables(schema.tables)
-        }
-
-        if (table) {
-          setOpenTable(table)
-          setVisibleColumns(table.columns)
-        }
       }
     }
   }

--- a/daiquiri/metadata/assets/js/components/Schemas.js
+++ b/daiquiri/metadata/assets/js/components/Schemas.js
@@ -48,28 +48,56 @@ const Schemas = ({ schemas, activeItem, setActiveItem, getTooltip, onDoubleClick
 
         setOpenTable(table)
         if (refListTables.current) {
-            refListTables.current.scrollTop = 0
+          refListTables.current.scrollTop = 0
         }
         setVisibleColumns((isNil(table) || isNil(table.columns)) ? [] : table.columns)
         if (refListColumns.current) {
-            refListColumns.current.scrollTop = 0
+          refListColumns.current.scrollTop = 0
         }
 
       } else if (activeItem.type == 'table') {
-        // search for the table
-        const table = schemas.reduce((result, schema) => {
-          const table = (schema.tables || []).find(t => isEqual(t, activeItem))
-          return isNil(table) ? result : table
-        }, null )
+        if (!isNil(activeItem.schema)) {
+          // this is a newly created table, search for the schema and table
+          const [schema, table] = schemas.reduce((result, schema) => {
+            return schema.id == activeItem.schema ? (
+              [schema, (schema.tables || []).find(t => isEqual(t, activeItem))]
+            ) : result
+          }, [] )
+          if (schema) {
+            setOpenSchema(schema)
+            setVisibleTables(schema.tables)
+          }
 
-        if (table) {
-          setOpenTable(table)
-          setVisibleColumns(table.columns)
+          if (table) {
+            setOpenTable(table)
+            setVisibleColumns(table.columns)
+          }
+        } else {
+          setOpenTable(activeItem)
+          setVisibleColumns(activeItem.columns)
           if (refListColumns.current) {
               refListColumns.current.scrollTop = 0
           }
         }
 
+      } else if (activeItem.type == 'column') {
+        if (!isNil(activeItem.table)) {
+          // this is a newly created column, search for the schema and table
+          const [schema, table] = schemas.reduce((result, schema) => {
+            const table = (schema.tables || []).find(t => (t.id == activeItem.table))
+            return isNil(table) ? result : [schema, table]
+          }, [])
+
+          if (schema) {
+            setOpenSchema(schema)
+            setVisibleTables(schema.tables)
+          }
+
+          if (table) {
+            setOpenTable(table)
+            setVisibleColumns(table.columns)
+          }
+        }
       }
     }
   }

--- a/daiquiri/metadata/assets/js/components/Schemas.js
+++ b/daiquiri/metadata/assets/js/components/Schemas.js
@@ -63,6 +63,7 @@ const Schemas = ({ schemas, activeItem, setActiveItem, getTooltip, onDoubleClick
               [schema, (schema.tables || []).find(t => isEqual(t, activeItem))]
             ) : result
           }, [] )
+
           if (schema) {
             setOpenSchema(schema)
             setVisibleTables(schema.tables)

--- a/daiquiri/metadata/models.py
+++ b/daiquiri/metadata/models.py
@@ -244,7 +244,11 @@ class Table(models.Model):
 
     def discover(self, adapter):
         metadata = adapter.fetch_table(self.schema.name, self.name)
-        self.type = metadata['type']
+        try:
+            self.type = metadata['type']
+        except KeyError:
+            # if the table does not exist in the database then do nothing
+            return
         self.nrows = adapter.fetch_nrows(self.schema.name, self.name)
         self.size = adapter.fetch_size(self.schema.name, self.name)
 


### PR DESCRIPTION
This PR fixes two issues
 - the list of schemas and tables in the DB browser do not update after click on the column anymore. Also, the list of schemas is not updated after the click on a table.
 - The list of tables/columns now always start at the top of the list if the list is updated by clicking new schema/table.