### PR TITLE
Add daiquiri-admin and scripts for npm, build, clean

### DIFF
--- a/daiquiri/__main__.py
+++ b/daiquiri/__main__.py
@@ -1,0 +1,27 @@
+'''
+Runs daiquiri-admin when the daiquiri module is run as a script, much like django-admin
+(see: https://github.com/django/django/blob/main/django/__main__.py):
+
+    python -m daiquiri check
+
+The main method is added as script in pyproject.toml so that
+
+    daiquiri-admin check
+
+works as well. Unlike django-admin, a set of generic settings is used for the
+management scripts.
+'''
+
+import os
+
+from django.core import management
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "daiquiri.core.management.settings")
+
+
+def main():
+    management.execute_from_command_line()
+
+
+if __name__ == "__main__":
+    main()

--- a/daiquiri/core/management/commands/build.py
+++ b/daiquiri/core/management/commands/build.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        call_command('npm', 'ci')
+        call_command('npm', 'run', 'build:prod')
+        subprocess.call(['/bin/bash', '-c', f'{sys.executable} -m build'])

--- a/daiquiri/core/management/commands/clean.py
+++ b/daiquiri/core/management/commands/clean.py
@@ -1,0 +1,56 @@
+import os
+import shutil
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('command', choices=[
+            'all',
+            'dist',
+            'media',
+            'npm',
+            'python',
+            'static',
+        ])
+
+    def handle(self, *args, **options):
+        if options['command'] in ['all', 'dist']:
+            self.clean_dir('dist')
+            self.clean_dir('daiquiri.egg-info')
+        if options['command'] in ['all', 'media']:
+            self.clean_dir(settings.MEDIA_ROOT)
+        if options['command'] in ['all', 'npm']:
+            self.clean_dir('node_modules')
+        if options['command'] in ['all', 'static']:
+            self.clean_static()
+        if options['command'] in ['all', 'python']:
+            self.clean_python()
+
+    def clean_python(self):
+        for root, dirs, files in os.walk('.'):
+            for dir_name in dirs:
+                if dir_name == '__pycache__':
+                    self.clean_dir(os.path.join(root, dir_name), quiet=True)
+
+    def clean_static(self):
+        self.clean_dir(settings.STATIC_ROOT)
+
+        for path in [
+            'daiquiri/auth/static/',
+            'daiquiri/contact/static/',
+            'daiquiri/core/static/',
+            'daiquiri/metadata/static/',
+            'daiquiri/query/static/',
+            'daiquiri/serve/static/',
+        ]:
+            self.clean_dir(path)
+
+    def clean_dir(self, path, quiet=False):
+        if path and os.path.exists(path):
+            shutil.rmtree(path)
+            if not quiet:
+                print(f'Directory "{path}" has been removed!')

--- a/daiquiri/core/management/commands/npm.py
+++ b/daiquiri/core/management/commands/npm.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('command', nargs="*")
+
+    def handle(self, *args, **options):
+        nvm_dir = os.getenv('NVM_DIR')
+
+        if nvm_dir is None:
+            raise CommandError('NVM_DIR is not set, is nvm.sh installed?')
+
+        if not os.path.exists(nvm_dir):
+            raise CommandError('NVM_DIR does not exist, is nvm.sh installed?')
+
+        command = ' '.join(options['command'])
+        subprocess.call(['/bin/bash', '-c', f'source {nvm_dir}/nvm.sh; npm {command}'])

--- a/daiquiri/core/management/settings.py
+++ b/daiquiri/core/management/settings.py
@@ -1,0 +1,49 @@
+# ruff: noqa: F403, F405, I001, RUF005
+'''
+Generic settings to be used with daiquiri-admin outside of an daiquiri-app.
+'''
+from pathlib import Path
+
+from daiquiri.core.settings.django import *
+from daiquiri.core.settings.daiquiri import *
+from daiquiri.core.settings.logging import *
+
+from daiquiri.auth.settings import *
+from daiquiri.conesearch.settings import *
+from daiquiri.contact.settings import *
+from daiquiri.cutout.settings import *
+from daiquiri.datalink.settings import *
+from daiquiri.files.settings import *
+from daiquiri.metadata.settings import *
+from daiquiri.oai.settings import *
+from daiquiri.query.settings import *
+from daiquiri.registry.settings import *
+from daiquiri.serve.settings import *
+from daiquiri.stats.settings import *
+from daiquiri.tap.settings import *
+
+INSTALLED_APPS = DJANGO_APPS + [
+    'daiquiri.auth',
+    'daiquiri.conesearch',
+    'daiquiri.contact',
+    'daiquiri.core',
+    'daiquiri.datalink',
+    'daiquiri.files',
+    'daiquiri.jobs',
+    'daiquiri.metadata',
+    'daiquiri.oai',
+    'daiquiri.query',
+    'daiquiri.registry',
+    'daiquiri.serve',
+    'daiquiri.stats',
+    'daiquiri.tap',
+    'daiquiri.uws',
+]
+
+ROOT_URLCONF = ''
+
+DATABASES = {}
+
+STATIC_ROOT = 'static_root'
+
+FILES_BASE_PATH = QUERY_DOWNLOAD_DIR = Path().cwd()

--- a/daiquiri/core/settings/django.py
+++ b/daiquiri/core/settings/django.py
@@ -5,9 +5,13 @@ from django.utils.translation import gettext_lazy as _
 
 import daiquiri.core.env as env
 
-CONFIG_DIR = Path(find_spec('config').origin).parent
-BASE_DIR = CONFIG_DIR.parent
-DAIQUIRI_APP = BASE_DIR.name.replace('-', '_')
+try:
+    CONFIG_DIR = Path(find_spec('config').origin).parent
+    BASE_DIR = CONFIG_DIR.parent
+    DAIQUIRI_APP = BASE_DIR.name.replace('-', '_')
+except AttributeError:
+    BASE_DIR = Path().cwd()
+    DAIQUIRI_APP = None
 
 BASE_URL = env.get_url('BASE_URL', '/')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ homepage = "https://django-daiquiri.github.io"
 issues = "https://github.com/django-daiquiri/daiquiri/issues"
 repository = "https://github.com/django-daiquiri/daiquiri.git"
 
+[project.scripts]
+daiquiri-admin = "daiquiri.__main__:main"
+
 [tool.setuptools.packages.find]
 include = ["daiquiri*"]
 exclude = ["*assets*", "*tests*"]


### PR DESCRIPTION
This PR ports some functionality I developed for RDMO last year over to Daiquiri. I adds an `daiquiri-admin` executable that can be used in any directory. Right now, I can be used for 3 things:

```
daiquiri-admin npm run [watch|build|build:prod]  # shortcut for nvm use and npm run ...

daiquiri-admin build  # build the front-end and then the python package

daiquiri-admin clean [all|dist|media|npm|python|static]  # removes files which are gitignored
```