### PR TITLE
267 fix download forms

### DIFF
--- a/daiquiri/core/adapter/database/base.py
+++ b/daiquiri/core/adapter/database/base.py
@@ -329,8 +329,8 @@ class BaseDatabaseAdapter:
         else:
             if cell.ndim == 1:
                 # create an array string digestable by postgres
-                value = str(cell).replace('[', '{').replace(']', '}')
-                value = ', '.join(value.split())
+                value_list = ['NULL' if cell.mask[i] else str(cell[i]) for i in range(len(cell))]
+                value = '{' + ', '.join(value_list) + '}'
             elif isinstance(cell, str):
                 value = cell
             elif cell.dtype.char == 'S':

--- a/daiquiri/core/assets/js/components/form/Select.js
+++ b/daiquiri/core/assets/js/components/form/Select.js
@@ -13,6 +13,7 @@ const Select = ({ label, value, options, errors, onChange }) => {
       <label htmlFor={id} className="form-label">{label}</label>
       <select
         id={id}
+        key={id}
         className={classNames('form-control', {'is-invalid': errors})}
         value={value}
         onChange={(event) => onChange(event.target.value)}>

--- a/daiquiri/core/assets/js/components/table/TableCell.js
+++ b/daiquiri/core/assets/js/components/table/TableCell.js
@@ -39,7 +39,9 @@ const TableCell = ({ column, value, rowIndex, columnIndex, setActive, showModal 
       }
     } else {
       // this is not a reference, just render the value
-      return Array.isArray(value) ? `[${value.join(', ')}]` : _.toString(value)
+      return Array.isArray(value)
+        ? `[${value.map(v => v === null || v === undefined ? 'NULL' : _.toString(v)).join(', ')}]`
+        : _.toString(value);
     }
   }
 

--- a/daiquiri/core/assets/js/components/table/TableCell.js
+++ b/daiquiri/core/assets/js/components/table/TableCell.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import _ from 'lodash'
+
 import { getBasename, getFileUrl, getLinkUrl, getReferenceUrl, isImageColumn,
          isModalColumn, isFileColumn, isLinkColumn } from '../../utils/table.js'
 
@@ -37,7 +39,7 @@ const TableCell = ({ column, value, rowIndex, columnIndex, setActive, showModal 
       }
     } else {
       // this is not a reference, just render the value
-      return Array.isArray(value) ? `[${value.join(', ')}]` : value
+      return Array.isArray(value) ? `[${value.join(', ')}]` : _.toString(value)
     }
   }
 
@@ -50,7 +52,11 @@ const TableCell = ({ column, value, rowIndex, columnIndex, setActive, showModal 
 
 TableCell.propTypes = {
   column: PropTypes.object.isRequired,
-  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  value: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.bool
+  ]),
   rowIndex: PropTypes.number.isRequired,
   columnIndex: PropTypes.number.isRequired,
   setActive: PropTypes.func.isRequired,

--- a/daiquiri/core/assets/js/components/table/TableModalDatalinks.js
+++ b/daiquiri/core/assets/js/components/table/TableModalDatalinks.js
@@ -21,7 +21,7 @@ const TableModalDatalinks = ({ dataLinkId, dataLinks }) => {
       <div>
         <ul className="list-unstyled">
           {dlPreview.map((dataLink, index) => (
-            <li key={index}>
+            <li className="mb-1" key={index}>
               <a className="btn btn-primary btn-sm" href={dataLink.access_url} target="_blank" rel="noreferrer" data-bs-toggle="tooltip" title="Open viewer">
                 <i className="bi bi-eye"></i>
               </a>
@@ -31,7 +31,7 @@ const TableModalDatalinks = ({ dataLinkId, dataLinks }) => {
         </ul>
         <ul className="list-unstyled">
           {dlThis.map((dataLink, index) => (
-            <li key={index}>
+            <li className="mb-1" key={index}>
               <a className="btn btn-primary btn-sm" href={dataLink.access_url} data-bs-toggle="tooltip" title="Download file">
                 <i className="bi bi-download"></i>
               </a>

--- a/daiquiri/core/assets/scss/base/navigation.scss
+++ b/daiquiri/core/assets/scss/base/navigation.scss
@@ -13,6 +13,8 @@ nav {
                 position: relative;
 
                 ul.dropdown-menu {
+                    max-height: 50rem;
+                    overflow-y: auto;
                     position: absolute;
                     top: 0;
                     left: calc(100% - 0.66rem);

--- a/daiquiri/core/utils.py
+++ b/daiquiri/core/utils.py
@@ -208,18 +208,24 @@ def human2bytes(string):
         return number * 1024**5
 
 
+def bytes2human(size, gnu=True):
+    if gnu:
+        for unit in ['B', 'kB', 'MB', 'GB', 'TB', 'PB']:
+            if size < 1000.0 or unit == 'PB':
+                return f"{size:.1f} {unit}"
+            size /= 1000.0
+    else:
+        for unit in ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']:
+            if size < 1024.0 or unit == 'PiB':
+                return f"{size:.1f} {unit}"
+            size /= 1024.0
+
+
 def markdown(md):
-    return markdown_function(md, extensions=[
-                                    'fenced_code',
-                                    'attr_list',
-                                    'codehilite'
-                                    ],
-                                 extension_configs={
-                                    'codehilite':{
-                                        'guess_lang':'false'
-                                    }
-                                 }
-                             )
+    return markdown_function(md,
+            extensions=['fenced_code', 'attr_list', 'codehilite'],
+            extension_configs={'codehilite':{'guess_lang':'false'}}
+    )
 
 
 def make_query_dict_upper_case(input_dict):

--- a/daiquiri/query/assets/js/api/QueryApi.js
+++ b/daiquiri/query/assets/js/api/QueryApi.js
@@ -19,8 +19,8 @@ class QueryApi extends BaseApi {
     return this.get('/query/api/dropdowns/')
   }
 
-  static fetchDownloads() {
-    return this.get('/query/api/downloads/')
+  static fetchDownloadForms(id) {
+    return this.get(`/query/api/jobs/${id}/downloadforms/`)
   }
 
   static fetchSubmittedDownloads(id) {

--- a/daiquiri/query/assets/js/components/submit/job/JobDownload.js
+++ b/daiquiri/query/assets/js/components/submit/job/JobDownload.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { isNil, isEmpty } from 'lodash'
 
 import { jobPhaseClass, jobPhaseMessage } from 'daiquiri/query/assets/js/constants/job'
-import { useSubmittedDownloadsQuery, useDownloadsQuery } from 'daiquiri/query/assets/js/hooks/queries'
+import { useSubmittedDownloadsQuery, useDownloadFormsQuery } from 'daiquiri/query/assets/js/hooks/queries'
 import { useSubmitDownloadJobMutation } from 'daiquiri/query/assets/js/hooks/mutations'
 
 import ArchiveDownload from './downloads/ArchiveDownload'
@@ -14,7 +14,7 @@ const JobDownload = ({ job }) => {
 
   const mutation = useSubmitDownloadJobMutation()
 
-  const { data: downloads } = useDownloadsQuery()
+  const { data: downloadForms } = useDownloadFormsQuery(job.id)
 
   const { data: downloadJobs } = useSubmittedDownloadsQuery(job.id) || []
 
@@ -26,7 +26,7 @@ const JobDownload = ({ job }) => {
     <div className="query-download">
       <p className="mb-4">
         {
-          isEmpty(downloads) ? gettext('The download of the results is currently not available.') :
+          isEmpty(downloadForms) ? gettext('The download of the results is currently not available.') :
           gettext('For further processing of the data, you can create a file from the results table' +
                  ' and then download it to your local machine. For this file several formats are available.' +
                  ' Please choose a format from the list below.')
@@ -34,8 +34,8 @@ const JobDownload = ({ job }) => {
       </p>
 
       {
-        downloads && downloads.map((download, downloadIndex) => {
-          if (download.key == 'table') {
+        downloadForms && downloadForms.map((downloadForm, downloadIndex) => {
+          if (downloadForm.key == 'table') {
             return (
               <TableDownload
                 key={downloadIndex}
@@ -44,7 +44,7 @@ const JobDownload = ({ job }) => {
                 onSubmit={(data) => handleSubmit('table', data)}
               />
             )
-          } else if (download.key == 'archive') {
+          } else if (downloadForm.key == 'archive') {
             return (
               <ArchiveDownload
                 key={downloadIndex}
@@ -54,12 +54,14 @@ const JobDownload = ({ job }) => {
                 onSubmit={(data) => handleSubmit('archive', data)}
               />
             )
-          } else if (!isNil(download.form)) {
+          } else if (!isNil(downloadForm.form)) {
             return (
               <FormDownload
                 key={downloadIndex}
-                form={download.form}
-                onSubmit={(data) => handleSubmit(download.key, data)}
+                jobId={job.id}
+                downloadForm={downloadForm}
+                downloadJobs={downloadJobs || []}
+                onSubmit={(data) => handleSubmit(downloadForm.key, data)}
               />
             )
           }

--- a/daiquiri/query/assets/js/components/submit/job/downloads/FormDownload.js
+++ b/daiquiri/query/assets/js/components/submit/job/downloads/FormDownload.js
@@ -1,15 +1,85 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 
+import { bytes2human } from 'daiquiri/core/assets/js/utils/bytes'
 import Input from 'daiquiri/core/assets/js/components/form/Input'
 import Select from 'daiquiri/core/assets/js/components/form/Select'
 
-const FormDownload = ({ form, onSubmit }) => {
-  const initialValues = Object.fromEntries(
-    form.fields.filter(field => field.type != 'submit').map(field => [field.key, field.default_value || ''])
-  )
+const FormDownload = ({ jobId, downloadForm, downloadJobs, onSubmit }) => {
+
+  const form = downloadForm.form
+
+  const initialValues = form.fields ?
+    Object.fromEntries(
+      form.fields.filter(field => field.type != 'submit')
+                 .map(field => [field.key, field.default_value || ''])
+    ) : {}
 
   const [values, setValues] = useState(initialValues)
+
+  const [showSpinner, setShowSpinner] = useState(false);
+
+  const handleClick = () => {
+    setShowSpinner(true)
+    onSubmit(values)
+    setTimeout(() => {setShowSpinner(false)}, 2000)
+  }
+
+  const hasIncompleteJobs = downloadJobs.some(job => job.phase != 'COMPLETED' && job.phase != 'ERROR')
+
+  const formDownloadJobs = downloadJobs?.filter((job) => job.key == downloadForm.key)
+
+  const handleDownload = (downloadJob) => {
+    const url = `/query/api/jobs/${jobId}/download/${downloadJob.key}/${downloadJob.id}/?download=true`
+    window.location.href = url
+  }
+
+  const renderJob = (downloadJob) => {
+    switch (downloadJob.phase) {
+      case 'COMPLETED':
+        return downloadJob.size != 0 ? (
+          <li key={downloadJob.id} className="list-group-item">
+            <div className="row">
+            {
+              form.fields && form.fields.map((field, index) => (
+                <div key={index} className={field.width ? `col-md-${field.width}` : 'col-md-12'}>
+                {field.type == 'submit' ? (
+                    <button className="btn btn-link text-start"
+                            onClick={() => handleDownload(downloadJob)}>
+                      <i className="bi bi-download"></i>&nbsp;
+                      ({bytes2human(downloadJob.size)})
+                    </button>
+                  ) : (
+                    downloadJob[field.key]
+                  )
+                }
+                </div>)
+              )
+            }
+          </div>
+          </li>
+        ) : ('')
+      case 'ERROR':
+        return (
+          <li key={downloadJob.id} className="list-group-item">
+              <div className="row">
+              {
+                form.fields && form.fields.map((field, index) => (
+                  <div key={index} className={field.width ? `col-md-${field.width}` : 'col-md-12'}>
+                  {field.type == 'submit' ? (
+                      <span className="text-danger"><i className="bi bi-x-octagon-fill"></i> Error</span>
+                    ) : (
+                      downloadJob[field.key]
+                    )
+                  }
+                  </div>)
+                )
+              }
+            </div>
+          </li>
+        )
+      }
+  }
 
   return (
     <div className="card mb-4">
@@ -17,9 +87,12 @@ const FormDownload = ({ form, onSubmit }) => {
         {form.label}
       </div>
       <div className="card-body">
-        <div className="row">
+        <div className="row mb-4">
+          <p>{form.description}</p>
+        </div>
+        <div className="form-group row mb-2">
         {
-          form.fields.map((field, index) => (
+          form.fields && form.fields.map((field, index) => (
             <div key={index} className={field.width ? `col-md-${field.width}` : 'col-md-12'}>
               {
                 ['text', 'number'].includes(field.type) && (
@@ -44,25 +117,56 @@ const FormDownload = ({ form, onSubmit }) => {
               }
               {
                 field.type == 'submit' && (
-                  <div>
+                  <div className="mb-3 d-flex flex-column">
                     <label className="form-label">&nbsp;</label>
-                    <button type="button" className="btn btn-primary form-control" onClick={() => onSubmit(values)}>
-                      {field.label || gettext('Submit')}
-                    </button>
+                    { showSpinner || hasIncompleteJobs ? (
+                      <p className="text-primary">
+                        <span>
+                        <span className="spinner-border spinner-border-sm">
+                        </span>
+                          {gettext(' Creating..')}
+                        </span>
+                      </p>
+                    ) : (
+                      <button type="button" className="btn btn-primary" onClick={handleClick}>
+                        {field.label || gettext('Create file')}
+                      </button>
+                    )
+                    }
                   </div>
                 )
               }
             </div>
           ))
         }
-        </div>
+      </div>
+      <ul className="list-group list-group-flush">
+      {
+        formDownloadJobs && formDownloadJobs.map((download) => (
+          renderJob(download)
+        ))
+      }
+      {
+        formDownloadJobs && formDownloadJobs.some(download => download.phase == 'ERROR') && (
+          <li key="error-message" className="list-group-item">
+            <div className="row">
+              <p className="text-danger">
+                {gettext('Please contact the maintainers of this site if the errors persist.')}
+              </p>
+            </div>
+          </li>
+        )
+      }
+      </ul>
       </div>
     </div>
   )
 }
 
 FormDownload.propTypes = {
-  form: PropTypes.object.isRequired,
+  downloadForm: PropTypes.object.isRequired,
+  jobId: PropTypes.string.isRequired,
+  downloadJobs: PropTypes.array.isRequired,
   onSubmit: PropTypes.func.isRequired
 }
 

--- a/daiquiri/query/assets/js/hooks/queries.js
+++ b/daiquiri/query/assets/js/hooks/queries.js
@@ -50,10 +50,10 @@ export const useDropdownsQuery = () => {
   })
 }
 
-export const useDownloadsQuery = () => {
+export const useDownloadFormsQuery = (jobId) => {
   return useQuery({
-    queryKey: ['downloads'],
-    queryFn: () => QueryApi.fetchDownloads(),
+    queryKey: ['downloadforms', jobId],
+    queryFn: () => QueryApi.fetchDownloadForms(jobId),
     placeholderData: keepPreviousData
   })
 }

--- a/daiquiri/query/tasks.py
+++ b/daiquiri/query/tasks.py
@@ -208,12 +208,17 @@ def run_database_ingest_task(job_id, file_path):
         except OperationalError as e:
             # load the job again and check if the job was killed
             job = QueryJob.objects.get(pk=job_id)
-
             if job.phase != job.PHASE_ABORTED:
                 job.phase = job.PHASE_ERROR
                 job.error_summary = str(e)
                 logger.info('job %s failed (%s)', job.id, job.error_summary)
 
+        except Exception as e:
+            job = QueryJob.objects.get(pk=job_id)
+            if job.phase != job.PHASE_ABORTED:
+                job.phase = job.PHASE_ERROR
+                job.error_summary = 'Unknown error. Please contact the maintainers of this site if the error persists.'
+                logger.info('job %s failed (%s)', job.id, str(e))
         else:
             # get additional information about the completed job
             job.phase = job.PHASE_COMPLETED

--- a/daiquiri/query/validators.py
+++ b/daiquiri/query/validators.py
@@ -52,9 +52,7 @@ class UploadFileValidator:
 
         quota = get_quota(user, quota_settings='QUERY_UPLOAD_LIMIT')
         if file.size > quota:
-            raise ValidationError({
-                'file': self.message % quota
-            })
+            raise ValidationError([self.message % quota])
 
 
 class UploadParamValidator:

--- a/daiquiri/query/validators.py
+++ b/daiquiri/query/validators.py
@@ -5,6 +5,8 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import ValidationError
 
+from daiquiri.core.utils import bytes2human
+
 from .models import QueryJob
 from .utils import get_quota
 
@@ -52,7 +54,7 @@ class UploadFileValidator:
 
         quota = get_quota(user, quota_settings='QUERY_UPLOAD_LIMIT')
         if file.size > quota:
-            raise ValidationError([self.message % quota])
+            raise ValidationError([self.message % bytes2human(quota)])
 
 
 class UploadParamValidator:

--- a/daiquiri/query/viewsets.py
+++ b/daiquiri/query/viewsets.py
@@ -271,6 +271,30 @@ class QueryJobViewSet(RowViewSetMixin, viewsets.ModelViewSet):
 
         return Response(job.columns())
 
+    @action(detail=True, methods=['get'], url_name='download-forms',
+            url_path=r'downloadforms')
+    def download_forms(self, request, pk=None):
+        """This endpoint returns all download forms that are available for the job.
+        """
+        download_forms = []
+        try:
+            job = self.get_queryset().get(pk=pk)
+        except QueryJob.DoesNotExist as e:
+            raise NotFound from e
+
+        for query_download in settings.QUERY_DOWNLOADS:
+            model = query_download.get('model', None)
+            if model:
+                download_job = import_class(model)
+                if hasattr(download_job, 'get_form'):
+                    form = download_job().get_form(job)
+                    query_download['form'] = form
+            download_forms.append(query_download)
+
+        serializer = DownloadSerializer(download_forms, many=True)
+
+        return Response(serializer.data)
+
     @action(detail=True, methods=['get'], url_name='submitted-downloads',
             url_path=r'downloads')
     def get_downloads(self, request, pk=None):
@@ -300,9 +324,7 @@ class QueryJobViewSet(RowViewSetMixin, viewsets.ModelViewSet):
                         job_response[par] = getattr(download_job, par)
                 response.append(job_response)
 
-
         return Response(response)
-
 
     @action(detail=True, methods=['get'], url_name='download',
             url_path=r'download/(?P<download_key>[a-z\-]+)/(?P<download_job_id>[A-Za-z0-9\-]+)')

--- a/daiquiri/query/viewsets.py
+++ b/daiquiri/query/viewsets.py
@@ -211,7 +211,10 @@ class QueryJobViewSet(RowViewSetMixin, viewsets.ModelViewSet):
         })
         serializer.is_valid(raise_exception=True)
 
-        file_name = handle_file_upload(get_user_upload_directory(self.request.user), serializer.validated_data['file'])
+        file_name = handle_file_upload(
+            get_user_upload_directory(self.request.user),
+            serializer.validated_data['file']
+        )
 
         job = QueryJob(
             job_type=QueryJob.JOB_TYPE_INTERFACE,


### PR DESCRIPTION
Closes #267

Now, the custom download services can supply forms by defining a function `get_form(self, query_job)` in their model. 
For example
```py
    def get_form(self, query_job):
        if query_job.nrows > settings.CUSTOM_DOWNLOAD_MAX_ROWS:
         return {
            'label': settings.CUSTOM_DOWNLOAD_FORM['label'],
            'description':  f'The service is available only for query results that contain a maximum of {settings.CUSTOM_DOWNLOAD_MAX_ROWS:} rows.'
        }
        else:
            return settings.CUSTOM_DOWNLOAD_FORM
```

Basically, one can add any kind of complex conditions into the function and provide custom messages/description for every case. The description will be rendered on the webpage.
![image](https://github.com/user-attachments/assets/89580735-0ca7-421e-9160-9d90fc6f0d95)

If the conditional form is not required then there is no need to define `get_form`. Add the form directly to the settings `QUERY_DOWNLOADS` and it will be always shown on the download page.