### PR TITLE
Fix rendering of links for modals

### DIFF
--- a/daiquiri/core/assets/js/components/table/TableCell.js
+++ b/daiquiri/core/assets/js/components/table/TableCell.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types'
 
 import _ from 'lodash'
 
-import { getBasename, getFileUrl, getLinkUrl, getReferenceUrl, isImageColumn,
-         isModalColumn, isFileColumn, isLinkColumn } from '../../utils/table.js'
+import { getBasename, getFileUrl, getLinkUrl, getReferenceUrl,
+         isImageColumn, isModalColumn, isFileColumn, isLinkColumn, isRefColumn
+       } from '../../utils/table.js'
 
 const TableCell = ({ column, value, rowIndex, columnIndex, setActive, showModal }) => {
 
   const renderCell = () => {
-    if (column.ucd && column.ucd.includes('meta.ref')) {
+    if (isRefColumn(column)) {
       if (isModalColumn(column)) {
         // render the modal
         if (isImageColumn(column)) {

--- a/daiquiri/core/assets/js/components/table/TableCell.js
+++ b/daiquiri/core/assets/js/components/table/TableCell.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import _ from 'lodash'
 
 import { getBasename, getFileUrl, getLinkUrl, getReferenceUrl,
-         isImageColumn, isModalColumn, isFileColumn, isLinkColumn, isRefColumn
+         isImageColumn, isModalColumn, isFileColumn, isLinkColumn, isRefColumn, isNoteColumn
        } from '../../utils/table.js'
 
 const TableCell = ({ column, value, rowIndex, columnIndex, setActive, showModal }) => {
@@ -13,7 +13,7 @@ const TableCell = ({ column, value, rowIndex, columnIndex, setActive, showModal 
     if (isRefColumn(column)) {
       if (isModalColumn(column)) {
         // render the modal
-        if (isImageColumn(column)) {
+        if (isImageColumn(column) || isNoteColumn(column)) {
           value = getBasename(value)
         }
         return (

--- a/daiquiri/core/assets/js/components/table/TableModal.js
+++ b/daiquiri/core/assets/js/components/table/TableModal.js
@@ -27,11 +27,19 @@ const TableModal = ({ modal, modalValues, onNavigation }) => {
                   dataLinks && <TableModalDatalinks dataLinkId={modalValues.dataLinkId} dataLinks={dataLinks} />
                 }
                 {
-                  note && <pre>{note}</pre>
+                  note && (
+                    <div>
+                    <a href={modalValues.noteUrl}><span><i class="bi bi-download"></i>&nbsp;Download</span></a>
+                    <pre>{note}</pre>
+                    </div>
+                  )
                 }
                 {
                   modalValues.imageSrc && (
+                    <div>
+                    <a href={modalValues.imageSrc}><span><i class="bi bi-download"></i>&nbsp;Download</span></a>
                     <img className="d-block mx-auto" src={modalValues.imageSrc} alt={modalValues.title} />
+                    </div>
                   )
                 }
               </div>

--- a/daiquiri/core/assets/js/components/table/TableModalDatalinks.js
+++ b/daiquiri/core/assets/js/components/table/TableModalDatalinks.js
@@ -51,6 +51,7 @@ const TableModalDatalinks = ({ dataLinkId, dataLinks }) => {
         {dlPreviewImages.map((dataLink, dataLinkIndex) => (
             <div key={dataLinkIndex}>
                 <h5>{dataLink.description}</h5>
+                <a href={dataLink.access_url}><span><i class="bi bi-download"></i>&nbsp;Download</span></a>
                 <img src={dataLink.access_url} className="d-block img-fluid" alt='Image is missing, please contact the administrator.' />
             </div>
         ))}

--- a/daiquiri/core/assets/js/components/table/TableModalDatalinks.js
+++ b/daiquiri/core/assets/js/components/table/TableModalDatalinks.js
@@ -53,6 +53,7 @@ const TableModalDatalinks = ({ dataLinkId, dataLinks }) => {
                 <h5>{dataLink.description}</h5>
                 <a href={dataLink.access_url}><span><i class="bi bi-download"></i>&nbsp;Download</span></a>
                 <img src={dataLink.access_url} className="d-block img-fluid" alt='Image is missing, please contact the administrator.' />
+                <hr className="mb-4"></hr>
             </div>
         ))}
       </div>

--- a/daiquiri/core/assets/js/utils/table.js
+++ b/daiquiri/core/assets/js/utils/table.js
@@ -15,7 +15,7 @@ export const isRefColumn = (column) => column.ucd && column.ucd.includes('meta.r
 
 export const isLinkColumn = (column) => column.ucd && column.ucd.includes('meta.ref.url')
 
-export const isDataLinkColumn = (column) => column.ucd && column.ucd.includes('meta.id')
+export const isDataLinkColumn = (column) => column.ucd && column.ucd.includes('meta.ref.id')
 
 export const isImageColumn = (column) => column.ucd && column.ucd.includes('meta.image')
 
@@ -23,8 +23,8 @@ export const isNoteColumn = (column) => column.ucd && column.ucd.includes('meta.
 
 export const isFileColumn = (column) => column.ucd && column.ucd.includes('meta.file')
 
-export const isRefIDColumn = (column) => column.ucd && column.ucd.includes('meta.ref.id')
-
-export const isModalColumn = (column) => isRefIDColumn(column) && (
-    isDataLinkColumn(column) || isImageColumn(column) || isNoteColumn(column)
+export const isModalColumn = (column) => (column) && (
+  isDataLinkColumn(column) ||
+  (isImageColumn(column) && isRefColumn(column)) ||
+  (isNoteColumn(column) && isRefColumn(column))
 )

--- a/daiquiri/query/assets/js/components/submit/forms/dropdowns/SimbadDropdown.js
+++ b/daiquiri/query/assets/js/components/submit/forms/dropdowns/SimbadDropdown.js
@@ -60,11 +60,11 @@ const SimbadDropdown = ({ options, onClick }) => {
                             <td>{row.object}</td>
                             <td>{row.type}</td>
                             <td>
-                              <button className="btn btn-link" onClick={() => onClick({query_string: row.ra})}>
+                              <button className="btn btn-link" onClick={() => onClick('simbad', {query_string: row.ra})}>
                                 {row.ra}
                               </button>
                               {' '}
-                              <button className="btn btn-link" onClick={() => onClick({query_string: row.de})}>
+                              <button className="btn btn-link" onClick={() => onClick('simbad', {query_string: row.de})}>
                                 {row.de}
                               </button>
                             </td>

--- a/daiquiri/query/assets/js/components/submit/forms/dropdowns/VizierDropdown.js
+++ b/daiquiri/query/assets/js/components/submit/forms/dropdowns/VizierDropdown.js
@@ -61,7 +61,7 @@ const VizierDropdown = ({ options, onClick }) => {
                             <td>
                               <button
                                 className="btn btn-link"
-                                onClick={() => onClick({query_string: row.id})}
+                                onClick={() => onClick('vizier', {query_string: row.id})}
                               >
                                 {row.id}
                               </button>
@@ -69,14 +69,14 @@ const VizierDropdown = ({ options, onClick }) => {
                             <td>
                               <button
                                 className="btn btn-link"
-                                onClick={() => onClick({query_string: row.ra})}
+                                onClick={() => onClick('vizier', {query_string: row.ra})}
                               >
                                 {row.ra}
                               </button>
                               {' '}
                               <button
                                 className="btn btn-link"
-                                onClick={() => onClick({query_string: row.de})}
+                                onClick={() => onClick('vizier', {query_string: row.de})}
                               >
                                 {row.de}
                               </button>
@@ -84,7 +84,7 @@ const VizierDropdown = ({ options, onClick }) => {
                             <td>
                               <button
                                 className="btn btn-link"
-                                onClick={() => onClick({query_string: row.distance})}
+                                onClick={() => onClick('vizier', {query_string: row.distance})}
                               >
                                 {row.distance}
                               </button>

--- a/daiquiri/query/urls.py
+++ b/daiquiri/query/urls.py
@@ -35,5 +35,7 @@ urlpatterns = [
     path(r'api/', include(router.urls)),
 
     # query interface, needs to be last in list
+    # the default path is required to cover a case with a single trailing slash
+    re_path(r'^$', QueryView.as_view(), name='default'),
     re_path(r'[A-Za-z0-9-]*/$', QueryView.as_view(), name='query'),
 ]


### PR DESCRIPTION
This PR does the following
 - The link to the note modal is now using the basename instead of the full path to the file
 - The modals have a download button for images and notes. Otherwise it was not obvious how to download them.
 - The url path to the query app allows single trailing slash.
 - Minor styling changes and some code refactoring.