### PR TITLE
Add token authentication for file download

### DIFF
--- a/daiquiri/files/utils.py
+++ b/daiquiri/files/utils.py
@@ -126,3 +126,11 @@ def make_file_path_absolute(file_path: Union[Path, str]) -> Path:
 def make_file_path_relative(file_path: Union[Path, str]) -> Path:
     res_path = Path(file_path).relative_to(settings.FILES_BASE_PATH)
     return res_path
+
+
+def is_cli_request(request):
+    user_agent = request.META.get('HTTP_USER_AGENT', '').lower()
+    if 'wget' in user_agent or 'curl' in user_agent:
+        return True
+    return False
+


### PR DESCRIPTION
This PR allows downloading files using API token. 

Previously, `wget` and `curl` worked only with the publicly available files. If the access level for the directory was set to 'INTERNAL' or 'PRIVATE' then the download was not possible because the request was always redirected to the login page. 

Here, I'm using the `TokenAuthentication` class from the DRF in order to authenticate the user. 

I tested the implementation with curl and wget
```bash
wget --header 'Authorization: Token <token>'  <url_to_the_file>
curl -H 'Authorization: Token <token>'  <url_to_the_file>
```