### PR TITLE
Add job_id to the reference url

### DIFF
--- a/daiquiri/core/assets/js/components/table/TableCell.js
+++ b/daiquiri/core/assets/js/components/table/TableCell.js
@@ -56,6 +56,7 @@ const TableCell = ({ column, value, rowIndex, columnIndex, setActive, showModal 
 TableCell.propTypes = {
   column: PropTypes.object.isRequired,
   value: PropTypes.oneOfType([
+    PropTypes.array,
     PropTypes.number,
     PropTypes.string,
     PropTypes.bool

--- a/daiquiri/core/assets/js/utils/table.js
+++ b/daiquiri/core/assets/js/utils/table.js
@@ -1,6 +1,8 @@
 import { isString } from 'lodash'
 import { baseUrl } from './meta'
 
+import { useServeParams } from 'daiquiri/serve/assets/js/hooks/params'
+
 export const getBasename = (string) => {
   return isString(string) ? string.replace(/^.*[\\/]/, '') : string
 }
@@ -9,7 +11,11 @@ export const getFileUrl = (column, value) => `${baseUrl}/files/${value}`
 
 export const getLinkUrl = (column, value) => value
 
-export const getReferenceUrl = (column, value) => `${baseUrl}/serve/references/${column.name}/${value}`
+export const getReferenceUrl = (column, value) => {
+  const params = useServeParams()
+  const queryParameters = new URLSearchParams(params).toString()
+  return `${baseUrl}/serve/references/${column.name}/${value}?${queryParameters}`
+}
 
 export const isRefColumn = (column) => column.ucd && column.ucd.includes('meta.ref')
 

--- a/daiquiri/query/assets/js/components/submit/job/JobResults.js
+++ b/daiquiri/query/assets/js/components/submit/job/JobResults.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 import { jobPhaseClass, jobPhaseMessage } from 'daiquiri/query/assets/js/constants/job'
 import { useJobColumnsQuery, useJobRowsQuery } from 'daiquiri/query/assets/js/hooks/queries'
+import { ServeParamsProvider } from 'daiquiri/serve/assets/js/hooks/params'
 
 import Table from 'daiquiri/core/assets/js/components/table/Table'
 
@@ -15,13 +16,17 @@ const JobResults = ({ job }) => {
   const { data: columns } = useJobColumnsQuery(job, params)
   const { data: rows } = useJobRowsQuery(job, params)
 
+  const serveContextParams = { job_id: job.id }
+
   return job.phase == 'COMPLETED' ? (
+    <ServeParamsProvider value={ serveContextParams }>
     <Table
       columns={columns}
       rows={rows}
       params={params}
       setParams={setParams}
     />
+    </ServeParamsProvider>
   )  : (
     <p className={jobPhaseClass[job.phase]}>{jobPhaseMessage[job.phase]}</p>
   )

--- a/daiquiri/serve/assets/js/hooks/params.js
+++ b/daiquiri/serve/assets/js/hooks/params.js
@@ -1,0 +1,9 @@
+import { useContext, createContext } from 'react'
+
+
+const ServeParamsContext = createContext();
+export const useServeParams = () => {
+  const context = useContext(ServeParamsContext);
+  return context !== undefined ? context : {}
+}
+export const ServeParamsProvider = ServeParamsContext.Provider;

--- a/daiquiri/serve/views.py
+++ b/daiquiri/serve/views.py
@@ -28,7 +28,7 @@ def reference(request, key, value):
     if resolver is None:
         raise Http404()
 
-    url = resolver.resolve(key, value)
+    url = resolver.resolve(request, key, value)
     if url is None:
         raise Http404()
 


### PR DESCRIPTION
Currently, the resolver in the `serve` app can handle only two arguments `key` and `value`. The reference url created in the results table (case `meta.ref`) is of the form `/serve/reference/<column_name>/<value>`. 

This PR adds `job_id` as a parameters to the reference url `/serve/reference/<column_name>/<value>?job_id=<job_id>`. The job_id is provided only if it's present. For example, the reference URLs created in `/serve/table/<schema_name>/<table_name>` won't have the `job_id`. 

The job_id can provide some context to the resolver if needed. For example, one can implement a custom results viewer tailored to the project. Also, it can be handy to have the full list of objects in the viewer to make it possible to quickly click through them.