### PR TITLE
Add a limit (maxrec) on rows for all jobs

### DIFF
--- a/daiquiri/core/renderers/vosi.py
+++ b/daiquiri/core/renderers/vosi.py
@@ -81,6 +81,12 @@ class CapabilitiesRendererMixin:
         for upload_method in capability.get('upload_methods', []):
             self.node('uploadMethod', {'ivo-id': upload_method})
 
+        if capability.get('output_limit'):
+            self.start('outputLimit')
+            self.node('default', {'unit': 'row'}, capability.get('output_limit'))
+            self.node('hard', {'unit': 'row'}, capability.get('output_limit'))
+            self.end('outputLimit')
+
         if capability.get('upload_limit'):
             self.start('uploadLimit')
             self.node('hard', {'unit': 'byte'}, capability.get('upload_limit'))

--- a/daiquiri/jobs/renderers.py
+++ b/daiquiri/jobs/renderers.py
@@ -82,7 +82,7 @@ class UWSRenderer(XMLRenderer):
 
 class UWSErrorRenderer(ErrorRenderer):
 
-    media_type = '*/*'
+    media_type = 'application/xml'
 
     def render_votable(self, data, accepted_media_type=None, renderer_context=None):
         self.start('RESOURCE', {

--- a/daiquiri/jobs/settings.py
+++ b/daiquiri/jobs/settings.py
@@ -1,0 +1,7 @@
+
+JOB_MAX_RECORDS = {
+    'anonymous': 5000000,
+    'user': 5000000,
+    'users': {},
+    'groups': {}
+}

--- a/daiquiri/query/assets/js/components/submit/forms/FormSql.js
+++ b/daiquiri/query/assets/js/components/submit/forms/FormSql.js
@@ -5,9 +5,11 @@ import { isNil } from 'lodash'
 import { useLsState } from 'daiquiri/core/assets/js/hooks/ls'
 import { useDropdownsQuery, useFormQuery,
          useQueryLanguagesQuery, useQueuesQuery } from 'daiquiri/query/assets/js/hooks/queries'
+import { useStatusQuery } from 'daiquiri/query/assets/js/hooks/queries'
 import { useSubmitJobMutation } from 'daiquiri/query/assets/js/hooks/mutations'
 
 import Template from 'daiquiri/core/assets/js/components/Template'
+import Tooltip from 'daiquiri/core/assets/js/components/Tooltip'
 
 import Input from 'daiquiri/core/assets/js/components/form/Input'
 import Sql from 'daiquiri/core/assets/js/components/form/Sql'
@@ -22,6 +24,7 @@ import VizierDropdown from './dropdowns/VizierDropdown'
 
 const FormSql = ({ formKey, loadJob, query, queryLanguage }) => {
   const { data: form } = useFormQuery(formKey)
+  const { data: status } = useStatusQuery()
   const { data: queues } = useQueuesQuery()
   const { data: queryLanguages } = useQueryLanguagesQuery()
   const { data: dropdowns } = useDropdownsQuery()
@@ -155,6 +158,21 @@ const FormSql = ({ formKey, loadJob, query, queryLanguage }) => {
             onChange={(query) => setValues({...values, query})}
             editorRef={editorRef}
           />
+          { status && status.max_records && (
+            <small className="form-text text-muted">
+              {
+                interpolate(gettext('Maximum rows per query: %s. '),
+                  [status.max_records])
+              }
+              <Tooltip tooltip={{
+                title: interpolate(gettext(`The queries on our service are limited to %s rows. If you need more data,
+                    consider refining your query or retrieving data in smaller batches.`),
+                    [status.max_records]),
+                placement: 'right'}}>
+                <i className="bi bi-info-circle-fill"></i>
+              </Tooltip>
+            </small>
+          )}
         </div>
 
         <div className="row">

--- a/daiquiri/query/assets/js/components/submit/job/JobParameters.js
+++ b/daiquiri/query/assets/js/components/submit/job/JobParameters.js
@@ -10,7 +10,12 @@ const JobParameters = ({ job }) => {
       <dl className="row mb-0">
         <dt className="col-md-3 text-md-end">{gettext('Job status')}</dt>
         <dd className="col-md-9 mb-0">
-          <span className={jobPhaseBadge[job.phase]}>{job.phase_label}</span>
+          <span className={jobPhaseBadge[job.phase]}>{job.phase_label}</span>&nbsp;
+          {
+            job.result_status !== 'OK' ? (
+              <span className="badge text-bg-warning">{job.result_status}</span>
+            ) : ''
+          }
         </dd>
 
         {
@@ -62,7 +67,7 @@ const JobParameters = ({ job }) => {
           job.nrows !== null && (
             <>
               <dt className="col-md-3 text-md-end">{gettext('Number of rows')}</dt>
-              <dd className="col-md-9 mb-0">{job.nrows}</dd>
+            <dd className="col-md-9 mb-0">{job.nrows}{job.result_status !== 'OK' ? (` (${job.result_status})` ) : ''}</dd>
             </>
           )
         }

--- a/daiquiri/query/serializers.py
+++ b/daiquiri/query/serializers.py
@@ -107,6 +107,7 @@ class QueryJobRetrieveSerializer(serializers.ModelSerializer):
             'native_query',
             'actual_query',
             'queue',
+            'result_status',
             'nrows',
             'size',
             'sources',

--- a/daiquiri/query/viewsets.py
+++ b/daiquiri/query/viewsets.py
@@ -25,6 +25,7 @@ from daiquiri.core.utils import (
 )
 from daiquiri.core.viewsets import ChoicesViewSet, RowViewSetMixin
 from daiquiri.jobs.viewsets import AsyncJobViewSet, SyncJobViewSet
+from daiquiri.jobs.utils import get_max_records
 from daiquiri.stats.models import Record
 
 from .filters import JobFilterBackend
@@ -60,6 +61,7 @@ from .utils import (
 )
 
 
+
 class StatusViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     permission_classes = (HasPermission, )
     queryset = []
@@ -71,6 +73,7 @@ class StatusViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             'size': QueryJob.objects.get_size(request.user),
             'hash':  QueryJob.objects.get_hash(request.user),
             'quota': get_quota(request.user),
+            'max_records': get_max_records(request.user),
             'upload_limit': get_quota(request.user, quota_settings='QUERY_UPLOAD_LIMIT')
         })
 
@@ -92,7 +95,6 @@ class FormViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
             return FormListSerializer
         else:
             return FormDetailSerializer
-
 
 
 class DropdownViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
@@ -160,12 +162,12 @@ class QueryJobViewSet(RowViewSetMixin, viewsets.ModelViewSet):
             query_language=serializer.data.get('query_language'),
             query=serializer.data.get('query'),
             queue=serializer.data.get('queue'),
+            max_records=get_max_records(self.request.user),
             client_ip=get_client_ip(self.request)
         )
         job.process()
         job.save()
         job.run()
-
         # inject the job id into the serializers data
         serializer._data['id'] = job.id
 

--- a/daiquiri/tap/vo.py
+++ b/daiquiri/tap/vo.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 
 from daiquiri.core.constants import ACCESS_LEVEL_PUBLIC
 from daiquiri.core.vo import get_curation
+from daiquiri.jobs.utils import get_max_records
 from daiquiri.metadata.models import Schema
 from daiquiri.query.utils import get_quota
 
@@ -58,7 +59,8 @@ def get_capabilities():
                 'ivo://ivoa.net/std/TAPRegExt#upload-inline',
                 'ivo://ivoa.net/std/TAPRegExt#upload-https',
             ] if settings.TAP_UPLOAD else [],
-            'upload_limit': int(get_quota(None, quota_settings='QUERY_UPLOAD_LIMIT'))
+            'upload_limit': int(get_quota(None, quota_settings='QUERY_UPLOAD_LIMIT')),
+            'output_limit': int(get_max_records(None))
         },
         {
             'id': 'ivo://ivoa.net/std/TAP#async-1.1',

--- a/testing/config/settings/__init__.py
+++ b/testing/config/settings/__init__.py
@@ -9,6 +9,7 @@ from daiquiri.contact.settings import *
 from daiquiri.cutout.settings import *
 from daiquiri.datalink.settings import *
 from daiquiri.files.settings import *
+from daiquiri.jobs.settings import *
 from daiquiri.metadata.settings import *
 from daiquiri.oai.settings import *
 from daiquiri.query.settings import *


### PR DESCRIPTION
This PR adds a limit on the number of rows that can be retrieved in a single query. It's a standard in all TAP services. This will prevent users to download de facto unlimited data. 
For now, the default limit is set to 5 million rows. If the limit is reached the correct 'OVERFLOW' flag is set in the VO resources and it's also indicated in the query information card on the web interface.
![image](https://github.com/user-attachments/assets/07238b47-78a9-4c42-bb55-9d36e7521d62)
