### PR TITLE
Add query for the selected region in the scatter plot 

### DIFF
--- a/daiquiri/query/assets/js/components/Submit.js
+++ b/daiquiri/query/assets/js/components/Submit.js
@@ -33,7 +33,7 @@ const Submit = ({ formKey, jobId, query, queryLanguage, loadForm, loadJob, loadJ
         </div>
         <div className="col-lg-9 order-1 order-lg-2">
           {
-            jobId && <Job jobId={jobId} loadForm={loadForm} />
+            jobId && <Job jobId={jobId} loadForm={loadForm} loadJob={loadJob} />
           }
           {
             formKey && getForm()

--- a/daiquiri/query/assets/js/components/submit/job/Job.js
+++ b/daiquiri/query/assets/js/components/submit/job/Job.js
@@ -11,7 +11,7 @@ import JobResults from './JobResults'
 import JobPlot from './JobPlot'
 import JobDownload from './JobDownload'
 
-const Job = ({ jobId, loadForm }) => {
+const Job = ({ jobId, loadForm, loadJob }) => {
   const { data: job } = useJobQuery(jobId)
 
   const [activeTab, setActiveTab] = useLsState('daiquiri.query.job.activeTab', 'overview')
@@ -71,7 +71,7 @@ const Job = ({ jobId, loadForm }) => {
             activeTab === 'results' && <JobResults job={job} />
           }
           {
-            activeTab === 'plot' && <JobPlot job={job} />
+            activeTab === 'plot' && <JobPlot job={job} loadJob={loadJob}/>
           }
           {
             activeTab === 'download' && <JobDownload job={job} />
@@ -84,7 +84,8 @@ const Job = ({ jobId, loadForm }) => {
 
 Job.propTypes = {
   jobId: PropTypes.string.isRequired,
-  loadForm: PropTypes.func.isRequired
+  loadForm: PropTypes.func.isRequired,
+  loadJob: PropTypes.func.isRequired,
 }
 
 export default Job

--- a/daiquiri/query/assets/js/components/submit/job/JobPlot.js
+++ b/daiquiri/query/assets/js/components/submit/job/JobPlot.js
@@ -11,7 +11,7 @@ import Scatter from './plots/Scatter'
 
 import JobPlotType from './JobPlotType'
 
-const JobPlot = ({ job }) => {
+const JobPlot = ({ job, loadJob }) => {
 
   const [type, setType] = useState('scatter')
   const [columns, setColumns] = useState([])
@@ -22,10 +22,13 @@ const JobPlot = ({ job }) => {
   ))), [job])
 
   return job.phase == 'COMPLETED' ? (
+    job.nrows > 1000000 ? (
+      <h3>The plotting tool is available only for the query results with nrows fewer than 1M.</h3>
+    ): (
     <div>
       <JobPlotType type={type} setType={setType} />
       {
-        (type == 'scatter') && <Scatter job={job} columns={columns} />
+        (type == 'scatter') && <Scatter job={job} columns={columns} loadJob={loadJob} />
       }
       {
         (type == 'colorScatter') && <ColorScatter job={job} columns={columns} />
@@ -34,13 +37,15 @@ const JobPlot = ({ job }) => {
         (type == 'histogram') && <Histogram job={job} columns={columns} />
       }
     </div>
+    )
   ) : (
     <p className={jobPhaseClass[job.phase]}>{jobPhaseMessage[job.phase]}</p>
   )
 }
 
 JobPlot.propTypes = {
-  job: PropTypes.object.isRequired
+  job: PropTypes.object.isRequired,
+  loadJob: PropTypes.func.isRequired,
 }
 
 export default JobPlot

--- a/daiquiri/query/assets/js/components/submit/job/JobPlot.js
+++ b/daiquiri/query/assets/js/components/submit/job/JobPlot.js
@@ -23,7 +23,13 @@ const JobPlot = ({ job, loadJob }) => {
 
   return job.phase == 'COMPLETED' ? (
     job.nrows > 1000000 ? (
-      <h3>The plotting tool is available only for the query results with nrows fewer than 1M.</h3>
+    <div className="card text-center">
+      <div className="card-body d-flex justify-content-center align-items-center" style={{ height: '200px'}}>
+        <h4 className="card-title">
+            The plotting tool is available only for query results with fewer than 1 million rows.
+        </h4>
+      </div>
+    </div>
     ): (
     <div>
       <JobPlotType type={type} setType={setType} />

--- a/daiquiri/query/assets/js/components/submit/job/plots/ColorScatter.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ColorScatter.js
@@ -10,7 +10,7 @@ import ColorScatterPlot from './ColorScatterPlot'
 
 const ColorScatter = ({ job, columns }) => {
 
-  const [values, setValues] = useState({
+  const [plotValues, setPlotValues] = useState({
     x: {
       column: ''
     },
@@ -23,27 +23,27 @@ const ColorScatter = ({ job, columns }) => {
     }
   })
 
-  useEffect(() => setValues({
-    ...values,
+  useEffect(() => setPlotValues({
+    ...plotValues,
     x: {
-      ...values.x, column: isNil(columns[0]) ? '' : columns[0].name
+      ...plotValues.x, column: isNil(columns[0]) ? '' : columns[0].name
     },
     y: {
-      ...values.y, column: isNil(columns[1]) ? '' : columns[1].name
+      ...plotValues.y, column: isNil(columns[1]) ? '' : columns[1].name
     },
     z: {
-      ...values.z, column: isNil(columns[2]) ? '' : columns[2].name
+      ...plotValues.z, column: isNil(columns[2]) ? '' : columns[2].name
     }
   }), [columns])
 
-  const { data: x } = useJobPlotQuery(job, values.x.column)
-  const { data: y } = useJobPlotQuery(job, values.y.column)
-  const { data: z } = useJobPlotQuery(job, values.z.column)
+  const { data: x } = useJobPlotQuery(job, plotValues.x.column)
+  const { data: y } = useJobPlotQuery(job, plotValues.y.column)
+  const { data: z } = useJobPlotQuery(job, plotValues.z.column)
 
   return (
     <div>
-      <ColorScatterForm columns={columns} values={values} setValues={setValues} />
-      <ColorScatterPlot columns={columns} values={values} x={x} y={y} z={z} />
+      <ColorScatterForm columns={columns} plotValues={plotValues} setPlotValues={setPlotValues} />
+      <ColorScatterPlot columns={columns} plotValues={plotValues} x={x} y={y} z={z} />
     </div>
   )
 }

--- a/daiquiri/query/assets/js/components/submit/job/plots/ColorScatterForm.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ColorScatterForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import { cmaps } from 'daiquiri/query/assets/js/constants/plot'
 
-const ColorScatterForm = ({ columns, values, setValues }) => {
+const ColorScatterForm = ({ columns, plotValues, setPlotValues }) => {
   return (
     <div className="card mb-2">
       <div className="card-body">
@@ -14,8 +14,8 @@ const ColorScatterForm = ({ columns, values, setValues }) => {
             </label>
           </div>
           <div className="col-4">
-            <select className="form-select" id="scatter-plot-x-axis" value={values.x.column} onChange={(value) => {
-              setValues({...values, x: {...values.x, column: value.target.value}})
+            <select className="form-select" id="scatter-plot-x-axis" value={plotValues.x.column} onChange={(value) => {
+              setPlotValues({ ...plotValues, x: { ...plotValues.x, column: value.target.value } })
             }}>
               <option value="">---</option>
               {
@@ -31,8 +31,8 @@ const ColorScatterForm = ({ columns, values, setValues }) => {
             </label>
           </div>
           <div className="col-4">
-            <select className="form-select" id="scatter-plot-y-axis" value={values.y.column} onChange={(value) => {
-              setValues({...values, y: {...values.y, column: value.target.value}})
+            <select className="form-select" id="scatter-plot-y-axis" value={plotValues.y.column} onChange={(value) => {
+              setPlotValues({ ...plotValues, y: { ...plotValues.y, column: value.target.value } })
             }}>
               <option value="">---</option>
               {
@@ -48,8 +48,8 @@ const ColorScatterForm = ({ columns, values, setValues }) => {
             </label>
           </div>
           <div className="col-4">
-            <select className="form-select" id="scatter-plot-z-axis" value={values.z.column} onChange={(value) => {
-              setValues({...values, z: {...values.z, column: value.target.value}})
+            <select className="form-select" id="scatter-plot-z-axis" value={plotValues.z.column} onChange={(value) => {
+              setPlotValues({ ...plotValues, z: { ...plotValues.z, column: value.target.value } })
             }}>
               <option value="">---</option>
               {
@@ -63,8 +63,8 @@ const ColorScatterForm = ({ columns, values, setValues }) => {
             </label>
           </div>
           <div className="col-4">
-            <select className="form-select" id="scatter-plot-cmap" value={values.z.cmap} onChange={(value) => {
-              setValues({...values, z: {...values.z, cmap: value.target.value}})
+            <select className="form-select" id="scatter-plot-cmap" value={plotValues.z.cmap} onChange={(value) => {
+              setPlotValues({ ...plotValues, z: { ...plotValues.z, cmap: value.target.value } })
             }}>
               {
                 cmaps.map((cmap, cmapIndex) => <option key={cmapIndex} value={cmap}>{cmap}</option>)
@@ -79,8 +79,8 @@ const ColorScatterForm = ({ columns, values, setValues }) => {
 
 ColorScatterForm.propTypes = {
   columns: PropTypes.array.isRequired,
-  values: PropTypes.object.isRequired,
-  setValues: PropTypes.func.isRequired
+  plotValues: PropTypes.object.isRequired,
+  setPlotValues: PropTypes.func.isRequired
 }
 
 export default ColorScatterForm

--- a/daiquiri/query/assets/js/components/submit/job/plots/ColorScatterPlot.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ColorScatterPlot.js
@@ -6,7 +6,7 @@ import { isNil } from 'lodash'
 import { config, layout } from 'daiquiri/query/assets/js/constants/plot'
 import { getColumnLabel } from 'daiquiri/query/assets/js/utils/plot'
 
-const ColorScatterPlot = ({ columns, values, x, y, z  }) => {
+const ColorScatterPlot = ({ columns, plotValues, x, y, z }) => {
   if (isNil(x) || isNil(y) || isNil(z)) {
     return null
   } else {
@@ -24,10 +24,10 @@ const ColorScatterPlot = ({ columns, values, x, y, z  }) => {
                   marker: {
                     showscale: true,
                     color: z,
-                    colorscale: values.z.cmap,
+                    colorscale: plotValues.z.cmap,
                     colorbar: {
                       title: {
-                        text: getColumnLabel(columns, values.z.column),
+                        text: getColumnLabel(columns, plotValues.z.column),
                         side: 'right'
                       }
                     }
@@ -39,16 +39,16 @@ const ColorScatterPlot = ({ columns, values, x, y, z  }) => {
                 ...layout,
                 xaxis: {
                   title: {
-                    text: getColumnLabel(columns, values.x.column),
+                    text: getColumnLabel(columns, plotValues.x.column),
                   },
                 },
                 yaxis: {
                   title: {
-                    text: getColumnLabel(columns, values.y.column),
+                    text: getColumnLabel(columns, plotValues.y.column),
                   }
                 }
               }}
-              style={{width: '100%'}}
+              style={{ width: '100%' }}
               useResizeHandler={true}
               config={config}
             />
@@ -61,7 +61,7 @@ const ColorScatterPlot = ({ columns, values, x, y, z  }) => {
 
 ColorScatterPlot.propTypes = {
   columns: PropTypes.array.isRequired,
-  values: PropTypes.object.isRequired,
+  plotValues: PropTypes.object.isRequired,
   x: PropTypes.array,
   y: PropTypes.array,
   z: PropTypes.array

--- a/daiquiri/query/assets/js/components/submit/job/plots/ColorScatterPlot.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ColorScatterPlot.js
@@ -32,6 +32,7 @@ const ColorScatterPlot = ({ columns, values, x, y, z  }) => {
                       }
                     }
                   },
+                  hoverinfo: 'skip'
                 }
               ]}
               layout={{

--- a/daiquiri/query/assets/js/components/submit/job/plots/Histogram.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/Histogram.js
@@ -10,7 +10,7 @@ import HistogramPlot from './HistogramPlot'
 
 const Histogram = ({ job, columns }) => {
 
-  const [values, setValues] = useState({
+  const [plotValues, setPlotValues] = useState({
     x: {
       column: ''
     },
@@ -22,20 +22,20 @@ const Histogram = ({ job, columns }) => {
     bins: 20,
   })
 
-  useEffect(() => setValues({
-    ...values,
+  useEffect(() => setPlotValues({
+    ...plotValues,
     x: {
-      ...values.x, column: isNil(columns[0]) ? '' : columns[0].name
+      ...plotValues.x, column: isNil(columns[0]) ? '' : columns[0].name
     }
   }), [columns])
 
-  const { data: x } = useJobPlotQuery(job, values.x.column)
-  const { data: s } = useJobPlotQuery(job, values.s.column)
+  const { data: x } = useJobPlotQuery(job, plotValues.x.column)
+  const { data: s } = useJobPlotQuery(job, plotValues.s.column)
 
   return (
     <div>
-      <HistogramForm columns={columns} values={values} setValues={setValues} />
-      <HistogramPlot columns={columns} values={values} x={x} s={s} />
+      <HistogramForm columns={columns} plotValues={plotValues} setPlotValues={setPlotValues} />
+      <HistogramPlot columns={columns} plotValues={plotValues} x={x} s={s} />
     </div>
   )
 }

--- a/daiquiri/query/assets/js/components/submit/job/plots/HistogramForm.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/HistogramForm.js
@@ -4,12 +4,12 @@ import { useDebouncedCallback } from 'use-debounce'
 
 import { operations } from 'daiquiri/query/assets/js/constants/plot'
 
-const HistogramForm = ({ columns, values, setValues }) => {
-  const setBins = useDebouncedCallback((event) => setValues({
-    ...values, bins: event.target.value
+const HistogramForm = ({ columns, plotValues, setPlotValues }) => {
+  const setBins = useDebouncedCallback((event) => setPlotValues({
+    ...plotValues, bins: event.target.value
   }), 500)
-  const setSelectValue = useDebouncedCallback((event) => setValues({
-    ...values, s: {...values.s, value: event.target.value}
+  const setSelectValue = useDebouncedCallback((event) => setPlotValues({
+    ...plotValues, s: { ...plotValues.s, value: event.target.value }
   }), 500)
 
   return (
@@ -22,8 +22,8 @@ const HistogramForm = ({ columns, values, setValues }) => {
             </label>
           </div>
           <div className="col-4">
-            <select className="form-select" id="scatter-plot-column" value={values.x.column} onChange={(event) => {
-              setValues({...values, x: {...values.x, column: event.target.value}})
+            <select className="form-select" id="scatter-plot-column" value={plotValues.x.column} onChange={(event) => {
+              setPlotValues({ ...plotValues, x: { ...plotValues.x, column: event.target.value } })
             }}>
               <option>---</option>
               {
@@ -39,7 +39,7 @@ const HistogramForm = ({ columns, values, setValues }) => {
             </label>
           </div>
           <div className="col-4">
-            <input type="number" className="form-control" defaultValue={values.bins} onChange={setBins} />
+            <input type="number" className="form-control" defaultValue={plotValues.bins} onChange={setBins} />
           </div>
         </div>
         <div className="row mt-1 align-items-center">
@@ -49,8 +49,8 @@ const HistogramForm = ({ columns, values, setValues }) => {
             </label>
           </div>
           <div className="col-4">
-            <select className="form-select" id="scatter-plot-select" value={values.s.column} onChange={(event) => {
-              setValues({...values, s: {...values.s, column: event.target.value}})
+            <select className="form-select" id="scatter-plot-select" value={plotValues.s.column} onChange={(event) => {
+              setPlotValues({ ...plotValues, s: { ...plotValues.s, column: event.target.value } })
             }}>
               <option value="">---</option>
               {
@@ -59,8 +59,8 @@ const HistogramForm = ({ columns, values, setValues }) => {
             </select>
           </div>
           <div className="col-2">
-            <select className="form-select" value={values.s.operation} onChange={(event) => {
-              setValues({...values, s: {...values.s, operation: event.target.value}})
+            <select className="form-select" value={plotValues.s.operation} onChange={(event) => {
+              setPlotValues({ ...plotValues, s: { ...plotValues.s, operation: event.target.value } })
             }}>
               {
                 operations.map((operation, operationIndex) => <option key={operationIndex} value={operation.name}>{operation.name}</option>)
@@ -68,7 +68,7 @@ const HistogramForm = ({ columns, values, setValues }) => {
             </select>
           </div>
           <div className="col-4">
-            <input type="number" className="form-control" defaultValue={values.s.value} onChange={setSelectValue} />
+            <input type="number" className="form-control" defaultValue={plotValues.s.value} onChange={setSelectValue} />
           </div>
         </div>
       </div>
@@ -78,8 +78,8 @@ const HistogramForm = ({ columns, values, setValues }) => {
 
 HistogramForm.propTypes = {
   columns: PropTypes.array.isRequired,
-  values: PropTypes.object.isRequired,
-  setValues: PropTypes.func.isRequired
+  plotValues: PropTypes.object.isRequired,
+  setPlotValues: PropTypes.func.isRequired
 }
 
 export default HistogramForm

--- a/daiquiri/query/assets/js/components/submit/job/plots/HistogramPlot.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/HistogramPlot.js
@@ -6,7 +6,7 @@ import { isNil } from 'lodash'
 import { config, layout, operations } from 'daiquiri/query/assets/js/constants/plot'
 import { getColumnLabel } from 'daiquiri/query/assets/js/utils/plot'
 
-const HistogramPlot = ({ columns, values, x, s }) => {
+const HistogramPlot = ({ columns, plotValues, x, s }) => {
   if (isNil(x)) {
     return null
   } else {
@@ -14,17 +14,17 @@ const HistogramPlot = ({ columns, values, x, s }) => {
       {
         x: x,
         type: 'histogram',
-        nbinsx: values.bins
+        nbinsx: plotValues.bins
       }
     ]
 
     if (!isNil(s)) {
-      const operation = operations.find(operation => operation.name == values.s.operation) || operations[0]
+      const operation = operations.find(operation => operation.name == plotValues.s.operation) || operations[0]
 
       data.push({
-        x: x.filter((value, index) => operation.operation(s[index], values.s.value)),
+        x: x.filter((value, index) => operation.operation(s[index], plotValues.s.value)),
         type: 'histogram',
-        nbinsx: values.bins
+        nbinsx: plotValues.bins
       })
     }
 
@@ -39,7 +39,7 @@ const HistogramPlot = ({ columns, values, x, s }) => {
                 bargap: 0.1,
                 xaxis: {
                   title: {
-                    text: getColumnLabel(columns, values.x.column),
+                    text: getColumnLabel(columns, plotValues.x.column),
                   },
                 },
                 yaxis: {
@@ -48,7 +48,7 @@ const HistogramPlot = ({ columns, values, x, s }) => {
                   }
                 }
               }}
-              style={{width: '100%'}}
+              style={{ width: '100%' }}
               useResizeHandler={true}
               config={config}
             />
@@ -61,7 +61,7 @@ const HistogramPlot = ({ columns, values, x, s }) => {
 
 HistogramPlot.propTypes = {
   columns: PropTypes.array.isRequired,
-  values: PropTypes.object.isRequired,
+  plotValues: PropTypes.object.isRequired,
   x: PropTypes.array,
   s: PropTypes.array,
 }

--- a/daiquiri/query/assets/js/components/submit/job/plots/Scatter.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/Scatter.js
@@ -10,7 +10,7 @@ import ScatterPlot from './ScatterPlot'
 
 const Scatter = ({ job, columns, loadJob }) => {
 
-  const [values, setValues] = useState({
+  const [plotValues, setPlotValues] = useState({
     x: {
       column: '',
     },
@@ -21,23 +21,23 @@ const Scatter = ({ job, columns, loadJob }) => {
     }
   })
 
-  useEffect(() => setValues({
-    ...values,
+  useEffect(() => setPlotValues({
+    ...plotValues,
     x: {
-      ...values.x, column: isNil(columns[0]) ? '' : columns[0].name
+      ...plotValues.x, column: isNil(columns[0]) ? '' : columns[0].name
     },
     y: {
-      ...values.y, column: isNil(columns[1]) ? '' : columns[1].name
+      ...plotValues.y, column: isNil(columns[1]) ? '' : columns[1].name
     }
   }), [columns])
 
-  const { data: x } = useJobPlotQuery(job, values.x.column)
-  const { data: y } = useJobPlotQuery(job, values.y.column)
+  const { data: x } = useJobPlotQuery(job, plotValues.x.column)
+  const { data: y } = useJobPlotQuery(job, plotValues.y.column)
 
   return (
     <div>
-      <ScatterForm columns={columns} values={values} setValues={setValues} />
-      { job && <ScatterPlot columns={columns} values={values} x={x} y={y} loadJob={loadJob} job={job}/>}
+      <ScatterForm columns={columns} plotValues={plotValues} setPlotValues={setPlotValues} />
+      {job && <ScatterPlot columns={columns} plotValues={plotValues} x={x} y={y} loadJob={loadJob} job={job} />}
     </div>
   )
 }

--- a/daiquiri/query/assets/js/components/submit/job/plots/Scatter.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/Scatter.js
@@ -8,26 +8,16 @@ import { useJobPlotQuery } from 'daiquiri/query/assets/js/hooks/queries'
 import ScatterForm from './ScatterForm'
 import ScatterPlot from './ScatterPlot'
 
-const Scatter = ({ job, columns }) => {
+const Scatter = ({ job, columns, loadJob }) => {
 
   const [values, setValues] = useState({
     x: {
       column: '',
     },
-    y1: {
+    y: {
       column: '',
       color: colors[0].hex,
       symbol: symbols[0].symbol
-    },
-    y2: {
-      column: '',
-      color: colors[1].hex,
-      symbol: symbols[1].symbol
-    },
-    y3: {
-      column: '',
-      color: colors[2].hex,
-      symbol: symbols[2].symbol
     }
   })
 
@@ -36,27 +26,26 @@ const Scatter = ({ job, columns }) => {
     x: {
       ...values.x, column: isNil(columns[0]) ? '' : columns[0].name
     },
-    y1: {
-      ...values.y1, column: isNil(columns[1]) ? '' : columns[1].name
+    y: {
+      ...values.y, column: isNil(columns[1]) ? '' : columns[1].name
     }
   }), [columns])
 
   const { data: x } = useJobPlotQuery(job, values.x.column)
-  const { data: y1 } = useJobPlotQuery(job, values.y1.column)
-  const { data: y2 } = useJobPlotQuery(job, values.y2.column)
-  const { data: y3 } = useJobPlotQuery(job, values.y3.column)
+  const { data: y } = useJobPlotQuery(job, values.y.column)
 
   return (
     <div>
       <ScatterForm columns={columns} values={values} setValues={setValues} />
-      <ScatterPlot columns={columns} values={values} x={x} y1={y1} y2={y2} y3={y3} />
+      { job && <ScatterPlot columns={columns} values={values} x={x} y={y} loadJob={loadJob} job={job}/>}
     </div>
   )
 }
 
 Scatter.propTypes = {
   job: PropTypes.object.isRequired,
-  columns: PropTypes.array.isRequired
+  columns: PropTypes.array.isRequired,
+  loadJob: PropTypes.func.isRequired,
 }
 
 export default Scatter

--- a/daiquiri/query/assets/js/components/submit/job/plots/ScatterForm.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ScatterForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import { colors, symbols } from 'daiquiri/query/assets/js/constants/plot'
 
-const ScatterForm = ({ columns, values, setValues }) => {
+const ScatterForm = ({ columns, plotValues, setPlotValues }) => {
 
   const getSymbolHtml = (symbol) => {
     const s = symbols.find(s => s.symbol == symbol)
@@ -22,8 +22,8 @@ const ScatterForm = ({ columns, values, setValues }) => {
             </label>
           </div>
           <div className="col-4">
-            <select className="form-select" id="scatter-plot-x-axis" value={values.x.column} onChange={(value) => {
-              setValues({...values, x: {...values.x, column: value.target.value}})
+            <select className="form-select" id="scatter-plot-x-axis" value={plotValues.x.column} onChange={(value) => {
+              setPlotValues({ ...plotValues, x: { ...plotValues.x, column: value.target.value } })
             }}>
               <option value="">---</option>
               {
@@ -40,8 +40,8 @@ const ScatterForm = ({ columns, values, setValues }) => {
               </label>
             </div>
             <div className="col-4">
-              <select className="form-select" id="scatter-plot-y-axis" value={values.y.column} onChange={(value) => {
-                setValues({...values, y: {...values.y, column: value.target.value}})
+              <select className="form-select" id="scatter-plot-y-axis" value={plotValues.y.column} onChange={(value) => {
+                setPlotValues({ ...plotValues, y: { ...plotValues.y, column: value.target.value } })
               }}>
                 <option value="">---</option>
                 {
@@ -50,11 +50,11 @@ const ScatterForm = ({ columns, values, setValues }) => {
               </select>
             </div>
             <div className="col-1">
-              <div className="query-plot-color-symbol text-center" style={{color: values.y.color}}>{getSymbolHtml(values.y.symbol)}</div>
+              <div className="query-plot-color-symbol text-center" style={{ color: plotValues.y.color }}>{getSymbolHtml(plotValues.y.symbol)}</div>
             </div>
             <div className="col-2">
-              <select className="form-select" id="scatter-plot-y-color" value={values.y.color} onChange={(value) => {
-                setValues({...values, y: {...values.y, color: value.target.value}})
+              <select className="form-select" id="scatter-plot-y-color" value={plotValues.y.color} onChange={(value) => {
+                setPlotValues({ ...plotValues, y: { ...plotValues.y, color: value.target.value } })
               }}>
                 {
                   colors.map(color => <option key={color.hex} value={color.hex}>{color.name}</option>)
@@ -62,8 +62,8 @@ const ScatterForm = ({ columns, values, setValues }) => {
               </select>
             </div>
             <div className="col-3">
-              <select className="form-select" id="scatter-plot-y-symbol" value={values.y.symbol} onChange={(value) => {
-                setValues({...values, y: {...values.y, symbol: value.target.value}})
+              <select className="form-select" id="scatter-plot-y-symbol" value={plotValues.y.symbol} onChange={(value) => {
+                setPlotValues({ ...plotValues, y: { ...plotValues.y, symbol: value.target.value } })
               }}>
                 {
                   symbols.map(symbol => <option key={symbol.symbol} value={symbol.symbol}>{symbol.name}</option>)
@@ -79,8 +79,8 @@ const ScatterForm = ({ columns, values, setValues }) => {
 
 ScatterForm.propTypes = {
   columns: PropTypes.array.isRequired,
-  values: PropTypes.object.isRequired,
-  setValues: PropTypes.func.isRequired
+  plotValues: PropTypes.object.isRequired,
+  setPlotValues: PropTypes.func.isRequired
 }
 
 export default ScatterForm

--- a/daiquiri/query/assets/js/components/submit/job/plots/ScatterForm.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ScatterForm.js
@@ -5,12 +5,6 @@ import { colors, symbols } from 'daiquiri/query/assets/js/constants/plot'
 
 const ScatterForm = ({ columns, values, setValues }) => {
 
-  const labels = {
-    y1: <span>Y<sub>1</sub></span>,
-    y2: <span>Y<sub>2</sub></span>,
-    y3: <span>Y<sub>3</sub></span>
-  }
-
   const getSymbolHtml = (symbol) => {
     const s = symbols.find(s => s.symbol == symbol)
     return (
@@ -39,46 +33,44 @@ const ScatterForm = ({ columns, values, setValues }) => {
           </div>
         </div>
         {
-          ['y1', 'y2', 'y3'].map(y => (
-            <div key={y} className="row mt-1 align-items-center">
-              <div className="col-2">
-                <label htmlFor={`scatter-plot-${y}-axis`} className="col-form-label">
-                  <strong>{labels[y]} axis</strong>
-                </label>
-              </div>
-              <div className="col-4">
-                <select className="form-select" id={`scatter-plot-${y}-axis`} value={values[y].column} onChange={(value) => {
-                  setValues({...values, [y]: {...values[y], column: value.target.value}})
-                }}>
-                  <option value="">---</option>
-                  {
-                    columns.map((column, columnIndex) => <option key={columnIndex} value={column.name}>{column.name}</option>)
-                  }
-                </select>
-              </div>
-              <div className="col-1">
-                <div className="query-plot-color-symbol text-center" style={{color: values[y].color}}>{getSymbolHtml(values[y].symbol)}</div>
-              </div>
-              <div className="col-2">
-                <select className="form-select" id={`scatter-plot-${y}-color`} value={values[y].color} onChange={(value) => {
-                  setValues({...values, [y]: {...values[y], color: value.target.value}})
-                }}>
-                  {
-                    colors.map(color => <option key={color.hex} value={color.hex}>{color.name}</option>)
-                  }
-                </select>
-              </div>
-              <div className="col-3">
-                <select className="form-select" id={`scatter-plot-${y}-symbol`} value={values[y].symbol} onChange={(value) => {
-                  setValues({...values, [y]: {...values[y], symbol: value.target.value}})
-                }}>
-                  {
-                    symbols.map(symbol => <option key={symbol.symbol} value={symbol.symbol}>{symbol.name}</option>)
-                  }
-                </select>
-              </div>
+          <div key="y" className="row mt-1 align-items-center">
+            <div className="col-2">
+              <label htmlFor={`scatter-plot-y-axis`} className="col-form-label">
+                <strong>Y axis</strong>
+              </label>
             </div>
-          ))
+            <div className="col-4">
+              <select className="form-select" id="scatter-plot-y-axis" value={values.y.column} onChange={(value) => {
+                setValues({...values, y: {...values.y, column: value.target.value}})
+              }}>
+                <option value="">---</option>
+                {
+                  columns.map((column, columnIndex) => <option key={columnIndex} value={column.name}>{column.name}</option>)
+                }
+              </select>
+            </div>
+            <div className="col-1">
+              <div className="query-plot-color-symbol text-center" style={{color: values.y.color}}>{getSymbolHtml(values.y.symbol)}</div>
+            </div>
+            <div className="col-2">
+              <select className="form-select" id="scatter-plot-y-color" value={values.y.color} onChange={(value) => {
+                setValues({...values, y: {...values.y, color: value.target.value}})
+              }}>
+                {
+                  colors.map(color => <option key={color.hex} value={color.hex}>{color.name}</option>)
+                }
+              </select>
+            </div>
+            <div className="col-3">
+              <select className="form-select" id="scatter-plot-y-symbol" value={values.y.symbol} onChange={(value) => {
+                setValues({...values, y: {...values.y, symbol: value.target.value}})
+              }}>
+                {
+                  symbols.map(symbol => <option key={symbol.symbol} value={symbol.symbol}>{symbol.name}</option>)
+                }
+              </select>
+            </div>
+          </div>
         }
       </div>
     </div>

--- a/daiquiri/query/assets/js/components/submit/job/plots/ScatterPlot.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ScatterPlot.js
@@ -1,78 +1,213 @@
-import React from 'react'
+import React, { useState, useRef, useEffect, useCallback, memo } from 'react'
 import PropTypes from 'prop-types'
 import Plot from 'react-plotly.js'
-import { isNil } from 'lodash'
+import { isNil, toString } from 'lodash'
 
 import { config, layout } from 'daiquiri/query/assets/js/constants/plot'
 import { getColumnLabel } from 'daiquiri/query/assets/js/utils/plot'
+import {
+  useFormQuery,
+  useQueuesQuery,
+} from 'daiquiri/query/assets/js/hooks/queries'
+import { useSubmitJobMutation } from 'daiquiri/query/assets/js/hooks/mutations'
 
-const ScatterPlot = ({ columns, values, x, y1, y2, y3  }) => {
+import Errors from 'daiquiri/core/assets/js/components/form/Errors'
+import Input from 'daiquiri/core/assets/js/components/form/Input'
+import Select from 'daiquiri/core/assets/js/components/form/Select'
+
+const MemoizedPlot = memo(({ columns, values, x, y, onSelected }) => {
+
+  const opacity = x.length > 100000 ? 0.25 : 0.6
+
+  const data = [{
+      x: x,
+      y: y,
+      type: 'scattergl',
+      mode: 'markers',
+      opacity: opacity,
+      marker : {
+        size: 5,
+        color: values.y.color,
+        symbol: values.y.symbol
+      },
+      hoverinfo: 'skip'
+  }]
+
+  const yLabel = getColumnLabel(columns, values.y.column)
+
+  return (
+    <Plot
+      data={data}
+      layout={{
+      ...layout,
+        xaxis: {
+          title: {
+            text: getColumnLabel(columns, values.x.column),
+          },
+        },
+        yaxis: {
+          title: {
+            text: yLabel,
+          }
+        }
+      }}
+      style={{ width: '100%' }}
+      useResizeHandler={true}
+      config={config}
+      onSelected={onSelected}
+    />
+  );
+});
+
+
+const ScatterPlot = ({ columns, values, x, y, loadJob, job }) => {
+  const { data: form } = useFormQuery('sql')
+  const { data: queues } = useQueuesQuery()
+
+  const [isClicked, setIsClicked] = useState(false);
+  const [text, setText] = useState('');
+  const [errors, setErrors] = useState({})
+
+
+  const [tableValues, setTableValues] = useState({
+    table_name: '',
+    run_id: '',
+    queue: '',
+    query: '',
+    query_language: job.query_language,
+  })
+
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true)
+  const selectedPointsRef = useRef({x:[], y:[], n: 0})
+
+  const mutation = useSubmitJobMutation()
+
+  const getDefaultQueue = () => (isNil(queues) ? '' : queues[0].id)
+
+  const handleSubmit = () => {
+    const polyPoints = selectedPointsRef.current.x
+    .map((x, index) => `${x} ${selectedPointsRef.current.y[index]}`)
+    .concat(`${selectedPointsRef.current.x[0]} ${selectedPointsRef.current.y[0]}`)
+    .join(', ');
+    const query = `SELECT *
+FROM "${job.schema_name}"."${job.table_name}" as t
+WHERE ST_Within(
+    ST_MakePoint(t.${values.x.column}, t.${values.y.column}),
+    ST_GeomFromText('POLYGON((${polyPoints}))')
+);`
+    tableValues.query = query
+    tableValues.queue = tableValues.queue == '' ?  getDefaultQueue() : ''
+
+    mutation.mutate({ values:tableValues, setErrors, loadJob })
+  }
+
+
+  const getInitialValues = () =>
+    isNil(form) || isEmpty(form.fields)
+      ? {}
+      : {
+          ...form.fields.reduce(
+            (initialValues, field) => ({
+              ...initialValues,
+              [field.key]: field.default_value || '',
+            }),
+            {}
+          ),
+        }
+
+  const handleSelection = useCallback((event) => {
+    console.log(event)
+    if (event && event.lassoPoints && event.lassoPoints.x.length > 0) {
+      selectedPointsRef.current = { x: event.lassoPoints.x, y: event.lassoPoints.y, n: event.points.length }
+      setIsButtonDisabled(false)
+    } else if (event && event.range && event.range.x.length > 0) {
+      selectedPointsRef.current = {
+        x: [event.range.x[0], event.range.x[0], event.range.x[1], event.range.x[1], event.range.x[0]],
+        y: [event.range.y[0], event.range.y[1], event.range.y[1], event.range.y[0], event.range.y[0]],
+        n: event.points.length }
+      setIsButtonDisabled(false)
+    } else {
+      selectedPointsRef.current = { x: [], y: [], n: 0}
+      setIsButtonDisabled(true)
+      setText('')
+    }
+  }, []);
+
   if (isNil(x)) {
     return null
-  } else {
-    const data = [[values.y1, y1], [values.y2, y2], [values.y3, y3]].reduce((data, [yValues, y]) => {
-      if (isNil(y)) {
-        return data
-      } else {
-        return [...data, {
-          x: x,
-          y: y,
-          type: 'scattergl',
-          mode: 'markers',
-          marker: {
-            color: yValues.color,
-            symbol: yValues.symbol
-          },
-          name: yValues.column
-        }]
-      }
-    }, [])
+  }
 
-    const yLabel = [[values.y1, y1], [values.y2, y2], [values.y3, y3]].reduce((label, [yValues, y]) => {
-      if (isNil(y)) {
-        return label
-      } else {
-        return [...label, getColumnLabel(columns, yValues.column)]
-      }
-    }, []).join(', ')
-
-    return (
-      <div className="card">
-        <div className="card-body">
-          <div className="ratio ratio-16x9">
-            <Plot
-              data={data}
-              layout={{
-                ...layout,
-                xaxis: {
-                  title: {
-                    text: getColumnLabel(columns, values.x.column),
-                  },
-                },
-                yaxis: {
-                  title: {
-                    text: yLabel,
-                  }
-                }
-              }}
-              style={{width: '100%'}}
-              useResizeHandler={true}
-              config={config}
-            />
-          </div>
+  return (
+    <div className="card">
+      <div className="card-body">
+        <div className="ratio ratio-16x9">
+          <MemoizedPlot
+            columns={columns}
+            values={values}
+            x={x}
+            y={y}
+            onSelected={handleSelection}
+          />
         </div>
       </div>
+        {
+          isButtonDisabled ?  (
+              <div className="card-footer text-secondary">
+              You can run a new query for a subset of the data by
+              selecting the points using the 'Select Lasso' or 'Select Box' tools.
+              </div>
+            ) : (
+              <div className="card-footer">
+                <div className="row">
+                    <div className="col-md-6">You have selected {selectedPointsRef.current.n} points.</div>
+                </div>
+                <div className="row">
+                  <div className="col-md-6">
+                    <Input
+                      label={gettext('Table name')}
+                      value={tableValues.table_name}
+                      errors={errors.table_name}
+                      onChange={(table_name) => setTableValues({ ...tableValues, table_name })}
+                    />
+                  </div>
+                  <div className="col-md-3">
+                    <Input
+                      label={gettext('Run id')}
+                      value={tableValues.run_id}
+                      errors={errors.run_id}
+                      onChange={(run_id) => setTableValues({ ...tableValues, run_id })}
+                    />
+                  </div>
+                  <div className="col-md-3">
+                    <Select
+                      label={gettext('Queue')}
+                      value={tableValues.queue}
+                      errors={errors.queue}
+                      options={queues}
+                      onChange={(queue) => setTableValues({ ...tableValues, queue })}
+                    />
+                  </div>
+                  <div className="col-md-3">
+                    <button
+                      className="btn btn-primary"
+                      onClick={() => handleSubmit()}
+                    >Run query</button>
+                  </div>
+                </div>
+              </div>
+            )
+          }
+        </div>
     )
   }
-}
 
-ScatterPlot.propTypes = {
-  columns: PropTypes.array.isRequired,
-  values: PropTypes.object.isRequired,
-  x: PropTypes.array,
-  y1: PropTypes.array,
-  y2: PropTypes.array,
-  y3: PropTypes.array
+  ScatterPlot.propTypes = {
+    columns: PropTypes.array.isRequired,
+    values: PropTypes.object.isRequired,
+    x: PropTypes.array,
+    y: PropTypes.array,
+    loadJob: PropTypes.func.isRequired,
+    job: PropTypes.object.isRequired
 }
 
 export default ScatterPlot

--- a/daiquiri/query/assets/js/components/submit/job/plots/ScatterPlot.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ScatterPlot.js
@@ -124,8 +124,8 @@ WHERE POLYGON '(${polyPoints})' @> POINT(t.${values.x.column}, t.${values.y.colu
       setIsButtonDisabled(false)
     } else if (event && event.range && event.range.x.length > 0) {
       selectedPointsRef.current = {
-        x: [event.range.x[0], event.range.x[0], event.range.x[1], event.range.x[1], event.range.x[0]],
-        y: [event.range.y[0], event.range.y[1], event.range.y[1], event.range.y[0], event.range.y[0]],
+        x: [event.range.x[0], event.range.x[0], event.range.x[1], event.range.x[1]],
+        y: [event.range.y[0], event.range.y[1], event.range.y[1], event.range.y[0]],
         n: event.points.length }
       setIsButtonDisabled(false)
     } else {
@@ -155,8 +155,7 @@ WHERE POLYGON '(${polyPoints})' @> POINT(t.${values.x.column}, t.${values.y.colu
         {
           isButtonDisabled ?  (
               <div className="card-footer text-secondary">
-              You can run a new query for a subset of the data by
-              selecting the points using the 'Select Lasso' or 'Select Box' tools.
+              Select points with the 'Lasso' or 'Box' tool to run a new query on the selected subset.
               </div>
             ) : (
               <div className="card-footer">

--- a/daiquiri/query/assets/js/components/submit/job/plots/ScatterPlot.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ScatterPlot.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback, memo } from 'react'
+import React, { useState, useRef, useCallback, memo } from 'react'
 import PropTypes from 'prop-types'
 import Plot from 'react-plotly.js'
 import { isNil, toString } from 'lodash'
@@ -6,7 +6,6 @@ import { isNil, toString } from 'lodash'
 import { config, layout } from 'daiquiri/query/assets/js/constants/plot'
 import { getColumnLabel } from 'daiquiri/query/assets/js/utils/plot'
 import {
-  useFormQuery,
   useQueryLanguagesQuery,
   useQueuesQuery,
 } from 'daiquiri/query/assets/js/hooks/queries'
@@ -16,34 +15,34 @@ import Errors from 'daiquiri/core/assets/js/components/form/Errors'
 import Input from 'daiquiri/core/assets/js/components/form/Input'
 import Select from 'daiquiri/core/assets/js/components/form/Select'
 
-const MemoizedPlot = memo(({ columns, values, x, y, onSelected }) => {
+const MemoizedPlot = memo(({ columns, plotValues, x, y, onSelected }) => {
 
   const opacity = x.length > 100000 ? 0.25 : 0.6
 
   const data = [{
-      x: x,
-      y: y,
-      type: 'scattergl',
-      mode: 'markers',
-      opacity: opacity,
-      marker : {
-        size: 5,
-        color: values.y.color,
-        symbol: values.y.symbol
-      },
-      hoverinfo: 'skip'
+    x: x,
+    y: y,
+    type: 'scattergl',
+    mode: 'markers',
+    opacity: opacity,
+    marker: {
+      size: 5,
+      color: plotValues.y.color,
+      symbol: plotValues.y.symbol
+    },
+    hoverinfo: 'skip'
   }]
 
-  const yLabel = getColumnLabel(columns, values.y.column)
+  const yLabel = getColumnLabel(columns, plotValues.y.column)
 
   return (
     <Plot
       data={data}
       layout={{
-      ...layout,
+        ...layout,
         xaxis: {
           title: {
-            text: getColumnLabel(columns, values.x.column),
+            text: getColumnLabel(columns, plotValues.x.column),
           },
         },
         yaxis: {
@@ -61,26 +60,21 @@ const MemoizedPlot = memo(({ columns, values, x, y, onSelected }) => {
 });
 
 
-const ScatterPlot = ({ columns, values, x, y, loadJob, job }) => {
-  const { data: form } = useFormQuery('sql')
-  const { data: queues } = useQueuesQuery()
-  const { data: queryLanguages } = useQueryLanguagesQuery()
-
-  const [isClicked, setIsClicked] = useState(false);
-  const [text, setText] = useState('');
+const ScatterPlot = ({ columns, plotValues, x, y, loadJob, job }) => {
+  const selectedPointsRef = useRef({ x: [], y: [], n: 0 })
   const [errors, setErrors] = useState({})
+  const [isFormDisabled, setIsFormDisabled] = useState(true)
 
-
-  const [tableValues, setTableValues] = useState({
+  const [values, setValues] = useState({
     table_name: '',
     run_id: '',
     queue: '',
     query: '',
-    query_language:'',
+    query_language: '',
   })
 
-  const [isButtonDisabled, setIsButtonDisabled] = useState(true)
-  const selectedPointsRef = useRef({x:[], y:[], n: 0})
+  const { data: queues } = useQueuesQuery()
+  const { data: queryLanguages } = useQueryLanguagesQuery()
 
   const mutation = useSubmitJobMutation()
 
@@ -88,50 +82,36 @@ const ScatterPlot = ({ columns, values, x, y, loadJob, job }) => {
 
   const handleSubmit = () => {
     const polyPoints = selectedPointsRef.current.x
-    .map((x, index) => `(${x}, ${selectedPointsRef.current.y[index]})`)
-    .concat(`(${selectedPointsRef.current.x[0]}, ${selectedPointsRef.current.y[0]})`)
-    .join(', ');
+      .map((x, index) => `(${x}, ${selectedPointsRef.current.y[index]})`)
+      .concat(`(${selectedPointsRef.current.x[0]}, ${selectedPointsRef.current.y[0]})`)
+      .join(', ');
     const query = `SELECT *
 FROM "${job.schema_name}"."${job.table_name}" as t
-WHERE POLYGON '(${polyPoints})' @> POINT(t.${values.x.column}, t.${values.y.column});`
+WHERE POLYGON '(${polyPoints})' @> POINT(t.${plotValues.x.column}, t.${plotValues.y.column});`
 
     const postgres = queryLanguages.find(language => toString(language.id).includes('postgres'))
-    tableValues.query_language = postgres ? postgres.id : job.query_language
+    values.query_language = postgres ? postgres.id : job.query_language
 
-    tableValues.query = query
-    tableValues.queue = tableValues.queue == '' ?  getDefaultQueue() : ''
+    values.query = query
+    values.queue = values.queue == '' ? getDefaultQueue() : ''
 
-    mutation.mutate({ values:tableValues, setErrors, loadJob })
+    mutation.mutate({ values: values, setErrors, loadJob })
   }
-
-
-  const getInitialValues = () =>
-    isNil(form) || isEmpty(form.fields)
-      ? {}
-      : {
-          ...form.fields.reduce(
-            (initialValues, field) => ({
-              ...initialValues,
-              [field.key]: field.default_value || '',
-            }),
-            {}
-          ),
-        }
 
   const handleSelection = useCallback((event) => {
     if (event && event.lassoPoints && event.lassoPoints.x.length > 0) {
       selectedPointsRef.current = { x: event.lassoPoints.x, y: event.lassoPoints.y, n: event.points.length }
-      setIsButtonDisabled(false)
+      setIsFormDisabled(false)
     } else if (event && event.range && event.range.x.length > 0) {
       selectedPointsRef.current = {
         x: [event.range.x[0], event.range.x[0], event.range.x[1], event.range.x[1]],
         y: [event.range.y[0], event.range.y[1], event.range.y[1], event.range.y[0]],
-        n: event.points.length }
-      setIsButtonDisabled(false)
+        n: event.points.length
+      }
+      setIsFormDisabled(false)
     } else {
-      selectedPointsRef.current = { x: [], y: [], n: 0}
-      setIsButtonDisabled(true)
-      setText('')
+      selectedPointsRef.current = { x: [], y: [], n: 0 }
+      setIsFormDisabled(true)
     }
   }, []);
 
@@ -145,70 +125,70 @@ WHERE POLYGON '(${polyPoints})' @> POINT(t.${values.x.column}, t.${values.y.colu
         <div className="ratio ratio-16x9">
           <MemoizedPlot
             columns={columns}
-            values={values}
+            plotValues={plotValues}
             x={x}
             y={y}
             onSelected={handleSelection}
           />
         </div>
       </div>
-        {
-          isButtonDisabled ?  (
-              <div className="card-footer text-secondary">
-              Select points with the 'Lasso' or 'Box' tool to run a new query on the selected subset.
+      {
+        isFormDisabled ? (
+          <div className="card-footer text-secondary">
+            Select points with the 'Lasso' or 'Box' tool to run a new query on the selected subset.
+          </div>
+        ) : (
+          <div className="card-footer">
+            <div className="row">
+              <div className="col-md-6">You have selected {selectedPointsRef.current.n} points. Please click 'Submit Query' to submit a new query for the selected region.</div>
+            </div>
+            <div className="row">
+              <div className="col-md-6">
+                <Input
+                  label={gettext('Table name')}
+                  value={values.table_name}
+                  errors={errors.table_name}
+                  onChange={(table_name) => setValues({ ...values, table_name })}
+                />
               </div>
-            ) : (
-              <div className="card-footer">
-                <div className="row">
-                    <div className="col-md-6">You have selected {selectedPointsRef.current.n} points.</div>
-                </div>
-                <div className="row">
-                  <div className="col-md-6">
-                    <Input
-                      label={gettext('Table name')}
-                      value={tableValues.table_name}
-                      errors={errors.table_name}
-                      onChange={(table_name) => setTableValues({ ...tableValues, table_name })}
-                    />
-                  </div>
-                  <div className="col-md-3">
-                    <Input
-                      label={gettext('Run id')}
-                      value={tableValues.run_id}
-                      errors={errors.run_id}
-                      onChange={(run_id) => setTableValues({ ...tableValues, run_id })}
-                    />
-                  </div>
-                  <div className="col-md-3">
-                    <Select
-                      label={gettext('Queue')}
-                      value={tableValues.queue}
-                      errors={errors.queue}
-                      options={queues}
-                      onChange={(queue) => setTableValues({ ...tableValues, queue })}
-                    />
-                  </div>
-                  <div className="col-md-3">
-                    <button
-                      className="btn btn-primary"
-                      onClick={() => handleSubmit()}
-                    >Run query</button>
-                  </div>
-                </div>
+              <div className="col-md-3">
+                <Input
+                  label={gettext('Run id')}
+                  value={values.run_id}
+                  errors={errors.run_id}
+                  onChange={(run_id) => setValues({ ...values, run_id })}
+                />
               </div>
-            )
-          }
-        </div>
-    )
-  }
+              <div className="col-md-3">
+                <Select
+                  label={gettext('Queue')}
+                  value={values.queue}
+                  errors={errors.queue}
+                  options={queues}
+                  onChange={(queue) => setValues({ ...values, queue })}
+                />
+              </div>
+              <div className="col-md-3">
+                <button
+                  className="btn btn-primary"
+                  onClick={() => handleSubmit()}
+                >Submit Query</button>
+              </div>
+            </div>
+          </div>
+        )
+      }
+    </div>
+  )
+}
 
-  ScatterPlot.propTypes = {
-    columns: PropTypes.array.isRequired,
-    values: PropTypes.object.isRequired,
-    x: PropTypes.array,
-    y: PropTypes.array,
-    loadJob: PropTypes.func.isRequired,
-    job: PropTypes.object.isRequired
+ScatterPlot.propTypes = {
+  columns: PropTypes.array.isRequired,
+  plotValues: PropTypes.object.isRequired,
+  x: PropTypes.array,
+  y: PropTypes.array,
+  loadJob: PropTypes.func.isRequired,
+  job: PropTypes.object.isRequired
 }
 
 export default ScatterPlot

--- a/daiquiri/query/assets/js/components/submit/job/plots/ScatterPlot.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ScatterPlot.js
@@ -86,15 +86,12 @@ const ScatterPlot = ({ columns, values, x, y, loadJob, job }) => {
 
   const handleSubmit = () => {
     const polyPoints = selectedPointsRef.current.x
-    .map((x, index) => `${x} ${selectedPointsRef.current.y[index]}`)
-    .concat(`${selectedPointsRef.current.x[0]} ${selectedPointsRef.current.y[0]}`)
+    .map((x, index) => `(${x}, ${selectedPointsRef.current.y[index]})`)
+    .concat(`(${selectedPointsRef.current.x[0]}, ${selectedPointsRef.current.y[0]})`)
     .join(', ');
     const query = `SELECT *
 FROM "${job.schema_name}"."${job.table_name}" as t
-WHERE ST_Within(
-    ST_MakePoint(t.${values.x.column}, t.${values.y.column}),
-    ST_GeomFromText('POLYGON((${polyPoints}))')
-);`
+WHERE POLYGON '(${polyPoints})' @> POINT(t.${values.x.column}, t.${values.y.column});`
     tableValues.query = query
     tableValues.queue = tableValues.queue == '' ?  getDefaultQueue() : ''
 

--- a/daiquiri/query/assets/js/components/submit/job/plots/ScatterPlot.js
+++ b/daiquiri/query/assets/js/components/submit/job/plots/ScatterPlot.js
@@ -140,7 +140,7 @@ WHERE POLYGON '(${polyPoints})' @> POINT(t.${plotValues.x.column}, t.${plotValue
         ) : (
           <div className="card-footer">
             <div className="row">
-              <div className="col-md-6">You have selected {selectedPointsRef.current.n} points. Please click 'Submit Query' to submit a new query for the selected region.</div>
+              <div className="col-md-12">You have selected {selectedPointsRef.current.n} points. Please click 'Submit Query' to submit a new query for the selected region.</div>
             </div>
             <div className="row">
               <div className="col-md-6">

--- a/daiquiri/query/assets/js/constants/plot.js
+++ b/daiquiri/query/assets/js/constants/plot.js
@@ -12,7 +12,7 @@ export const layout = {
 export const config = {
   displayModeBar: true,
   displaylogo: false,
-  modeBarButtonsToRemove: ['select2d', 'lasso2d']
+  modeBarButtonsToRemove: ['zoomIn', 'zoomOut', 'autoScale']
 }
 
 export const colors = [

--- a/daiquiri/query/assets/js/hooks/queries.js
+++ b/daiquiri/query/assets/js/hooks/queries.js
@@ -140,7 +140,7 @@ export const useJobPlotQuery = (job, column) => {
     queryKey: ['jobPlot', job.id, column],
     queryFn: () => {
       if (job.columns.map(column => column.name).includes(column)) {
-        return QueryApi.fetchJobRows(job.id, {column: column, page_size: 10000})
+        return QueryApi.fetchJobRows(job.id, {column: column, page_size: 1000000})
                              .then((response) => response.results)
       } else {
         return null
@@ -150,6 +150,8 @@ export const useJobPlotQuery = (job, column) => {
     enabled: job.phase == 'COMPLETED'
   })
 }
+
+
 
 export const useUserExamplesQuery = () => {
   return useQuery({


### PR DESCRIPTION
This PR allows to select a region using the 'Box' or 'Lasso' tool in the scatter plot and then submit a query for the selected region. This feature is only working for a postgres database since it's using the postgres native functions/types `polygon` and `point`.  
Basically, we construct a query out of the selection points
```sql
SELECT *
FROM "user_schema"."user_table" as t
WHERE POLYGON '("POLYGON POINTS")' @> POINT(t.selectedX, t.selectedY});
```
The features requires `python3-queryparser >= 0.7.3` , see aipescience/queryparser#24

__Note__: The selection work purely on a flat surface using Cartesian coordinates.  

![image](https://github.com/user-attachments/assets/8edd6ece-13c5-4ecb-ab37-9940e908fa7b)


